### PR TITLE
Add tags and update the finding frequency for GuardDuty

### DIFF
--- a/templates/guardduty.tmpl
+++ b/templates/guardduty.tmpl
@@ -4,8 +4,10 @@
 %{ if contains(service_regions, account_region) ~}
 # Enable GuardDuty in each available region
 resource "aws_guardduty_detector" "${baseline_provider_key}-${account_region}" {
-  provider = aws.${baseline_provider_key}-${account_region}
-  enable   = true
+  provider                     = aws.${baseline_provider_key}-${account_region}
+  enable                       = true
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
+  tags                         = var.baseline_tags
 }
 
 %{ else ~}

--- a/templates/variables.tf
+++ b/templates/variables.tf
@@ -3,3 +3,8 @@ variable "baseline_assume_role" {
   description = "Which role to assume to manage these resources"
   default     = ""
 }
+
+variable "baseline_tags" {
+  type        = map
+  description = "Tags to apply to taggable resources"
+}


### PR DESCRIPTION
This updates the `finding_publishing_frequency` from 6 hours to 15 minutes, and adds the ability to tag the GuardDuty resource.