### PR TITLE
Update README and update versions.tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,54 @@
 # modernisation-platform-terraform-baselines
 
-Terrafor module for enabling and creating baseline rules from the [MoJ Security Guidance](https://ministryofjustice.github.io/security-guidance/baseline-aws-accounts/#baseline-for-amazon-web-services-accounts).
+Terraform module for generating files to enable and create baseline rules from the [MoJ Security Guidance](https://ministryofjustice.github.io/security-guidance/baseline-aws-accounts/#baseline-for-amazon-web-services-accounts).
+
+## Enabled services
+- [ ] Security email setting
+- [x] GuardDuty
+- [ ] CloudTrail
+- [ ] Config
+- [ ] Tagging
+- [ ] Regions
+- [ ] Identity and Access Management
+- [ ] Encryption
+- [ ] World Access
+- [x] SecurityHub
+
+### Regions
+This module fetches the AWS regions that are enabled in the consuming account, and fetches the regions that services are available in, to cross-reference and enable services in each required region.
+These are commited to the [regions](regions) folder.
 
 ## Usage
 ```
 module "baselines" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines"
+  source                = "github.com/ministryofjustice/modernisation-platform-terraform-baselines"
+  baseline_directory    = "./generated"
+  baseline_provider_key = "aws"
 }
 ```
 
-## Inputs
-None
+Once files have been generated, you will have a set of files including `variables.tf` that can control enabled services, which can be used like so:
+
+```
+module "generated" {
+  source               = "./generated/aws"
+  baseline_tags        = local.tags
+  baseline_assume_role = local.assumable_role.arn
+}
+```
+
+## Inputs for baselines
+|          Name         |                             Description                             |   Type  | Default | Required |
+|:---------------------:|:-------------------------------------------------------------------:|:-------:|:-------:|----------|
+|  baseline_assume_role | Whether or not a role needs to be assumed to manage these resources | boolean |  false  | no       |
+|   baseline_directory  |         Directory to put this module's generated files into         |  string |         | yes      |
+| baseline_provider_key |        A unique provider key to use for provider definitions        |  string |         | yes      |
+
+## Inputs for generated files
+|         Name         |                      Description                      |  Type  | Default | Required |
+|:--------------------:|:-----------------------------------------------------:|:------:|:-------:|----------|
+| baseline_assume_role |      Role ARN to assume to manage these resources     | string |    ""   | no       |
+|     baseline_tags    |          Tags to apply to taggable resources          |   map  |         | yes      |
 
 ## Outputs
 None

--- a/templates/variables.tf
+++ b/templates/variables.tf
@@ -1,6 +1,6 @@
 variable "baseline_assume_role" {
   type        = string
-  description = "Which role to assume to manage these resources"
+  description = "Role ARN to assume to manage these resources"
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "baseline_assume_role" {
+  type        = bool
+  description = "Whether or not a role needs to be assumed to manage these resources"
+  default     = false
+}
+
 variable "baseline_directory" {
   type        = string
   description = "Directory to put this module's generated files into"
@@ -6,10 +12,4 @@ variable "baseline_directory" {
 variable "baseline_provider_key" {
   type        = string
   description = "A unique provider key to use for provider definitions"
-}
-
-variable "baseline_assume_role" {
-  type        = bool
-  description = "Whether or not a role needs to be assumed to manage these resources"
-  default     = false
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
Update the README to add a note about generated regions, how to use the module, and what services it enables. Also adds a versions.tf for Terraform 0.13, and alphabetises the `variables.tf` file.