### PR TITLE
Fix spacing issue for terraform fmt

### DIFF
--- a/templates/cloudtrail.tmpl
+++ b/templates/cloudtrail.tmpl
@@ -68,7 +68,7 @@ resource "aws_cloudwatch_log_group" "cloudtrail" {
   name       = "cloudtrail"
   kms_key_id = aws_kms_key.cloudtrail.arn
   tags       = var.baseline_tags
-  }
+}
 
 resource "aws_cloudwatch_log_stream" "cloudtrail_stream" {
   name           = data.aws_caller_identity.cloudtrail_current.account_id
@@ -164,9 +164,9 @@ data "aws_iam_policy_document" "cloudtrail" {
   }
 
   statement {
-    sid     = "Require SSL"
-    effect  = "Deny"
-    actions = ["s3:*"]
+    sid       = "Require SSL"
+    effect    = "Deny"
+    actions   = ["s3:*"]
     resources = ["$${aws_s3_bucket.cloudtrail.arn}/*"]
 
     principals {

--- a/templates/config.tmpl
+++ b/templates/config.tmpl
@@ -175,14 +175,14 @@ resource "aws_config_configuration_recorder_status" "${baseline_provider_key}-${
 # Create an SNS topic for each region
 resource "aws_sns_topic" "${baseline_provider_key}-${account_region}" {
   provider = aws.${baseline_provider_key}-${account_region}
-  name = "config"
-  tags = var.baseline_tags
+  name     = "config"
+  tags     = var.baseline_tags
 }
 
 resource "aws_sns_topic_policy" "${baseline_provider_key}-${account_region}" {
   provider = aws.${baseline_provider_key}-${account_region}
-  arn    = aws_sns_topic.${baseline_provider_key}-${account_region}.arn
-  policy = data.aws_iam_policy_document.sns_topic_policy-${baseline_provider_key}-${account_region}.json
+  arn      = aws_sns_topic.${baseline_provider_key}-${account_region}.arn
+  policy   = data.aws_iam_policy_document.sns_topic_policy-${baseline_provider_key}-${account_region}.json
 }
 
 data "aws_iam_policy_document" "sns_topic_policy-${baseline_provider_key}-${account_region}" {
@@ -227,16 +227,16 @@ data "aws_iam_policy_document" "sns_topic_policy-${baseline_provider_key}-${acco
 
 # Configure AWS Config rules
 resource "aws_config_config_rule" "access-keys-rotated" {
-  provider = aws.${baseline_provider_key}-${account_region}
-  name     = "access-keys-rotated"
+  provider                    = aws.${baseline_provider_key}-${account_region}
+  name                        = "access-keys-rotated"
   maximum_execution_frequency = "TwentyFour_Hours"
 
   input_parameters = jsonencode({
-    maxAccessKeyAge: "90"
+    maxAccessKeyAge : "90"
   })
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "ACCESS_KEYS_ROTATED"
   }
 
@@ -246,16 +246,16 @@ resource "aws_config_config_rule" "access-keys-rotated" {
 }
 
 resource "aws_config_config_rule" "account-part-of-organizations" {
-  provider = aws.${baseline_provider_key}-${account_region}
-  name     = "account-part-of-organizations"
+  provider                    = aws.${baseline_provider_key}-${account_region}
+  name                        = "account-part-of-organizations"
   maximum_execution_frequency = "TwentyFour_Hours"
 
   input_parameters = jsonencode({
-    MasterAccountId: var.baseline_root_account_id
+    MasterAccountId : var.baseline_root_account_id
   })
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "ACCOUNT_PART_OF_ORGANIZATIONS"
   }
 
@@ -265,12 +265,12 @@ resource "aws_config_config_rule" "account-part-of-organizations" {
 }
 
 resource "aws_config_config_rule" "cloud-trail-cloud-watch-logs-enabled" {
-  provider = aws.${baseline_provider_key}-${account_region}
-  name     = "cloud-trail-cloud-watch-logs-enabled"
+  provider                    = aws.${baseline_provider_key}-${account_region}
+  name                        = "cloud-trail-cloud-watch-logs-enabled"
   maximum_execution_frequency = "TwentyFour_Hours"
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "CLOUD_TRAIL_CLOUD_WATCH_LOGS_ENABLED"
   }
 
@@ -280,12 +280,12 @@ resource "aws_config_config_rule" "cloud-trail-cloud-watch-logs-enabled" {
 }
 
 resource "aws_config_config_rule" "cloud-trail-encryption-enabled" {
-  provider = aws.${baseline_provider_key}-${account_region}
-  name     = "cloud-trail-encryption-enabled"
+  provider                    = aws.${baseline_provider_key}-${account_region}
+  name                        = "cloud-trail-encryption-enabled"
   maximum_execution_frequency = "TwentyFour_Hours"
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "CLOUD_TRAIL_ENCRYPTION_ENABLED"
   }
 
@@ -295,12 +295,12 @@ resource "aws_config_config_rule" "cloud-trail-encryption-enabled" {
 }
 
 resource "aws_config_config_rule" "cloud-trail-log-file-validation-enabled" {
-  provider = aws.${baseline_provider_key}-${account_region}
-  name     = "cloud-trail-log-file-validation-enabled"
+  provider                    = aws.${baseline_provider_key}-${account_region}
+  name                        = "cloud-trail-log-file-validation-enabled"
   maximum_execution_frequency = "TwentyFour_Hours"
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "CLOUD_TRAIL_LOG_FILE_VALIDATION_ENABLED"
   }
 
@@ -314,7 +314,7 @@ resource "aws_config_config_rule" "iam-group-has-users-check" {
   name     = "iam-group-has-users-check"
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "IAM_GROUP_HAS_USERS_CHECK"
   }
 
@@ -328,7 +328,7 @@ resource "aws_config_config_rule" "iam-no-inline-policy-check" {
   name     = "iam-no-inline-policy-check"
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "IAM_NO_INLINE_POLICY_CHECK"
   }
 
@@ -338,22 +338,22 @@ resource "aws_config_config_rule" "iam-no-inline-policy-check" {
 }
 
 resource "aws_config_config_rule" "iam-password-policy" {
-  provider = aws.${baseline_provider_key}-${account_region}
-  name     = "iam-password-policy"
+  provider                    = aws.${baseline_provider_key}-${account_region}
+  name                        = "iam-password-policy"
   maximum_execution_frequency = "TwentyFour_Hours"
 
   input_parameters = jsonencode({
-    RequireUppercaseCharacters: "true",
-    RequireLowercaseCharacters: "true",
-    RequireSymbols: "true",
-    RequireNumbers: "true",
-    MinimumPasswordLength: "8",
-    PasswordReusePrevention: "5",
-    MaxPasswordAge: "0",
+    RequireUppercaseCharacters : "true",
+    RequireLowercaseCharacters : "true",
+    RequireSymbols : "true",
+    RequireNumbers : "true",
+    MinimumPasswordLength : "8",
+    PasswordReusePrevention : "5",
+    MaxPasswordAge : "0",
   })
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "IAM_PASSWORD_POLICY"
   }
 
@@ -363,12 +363,12 @@ resource "aws_config_config_rule" "iam-password-policy" {
 }
 
 resource "aws_config_config_rule" "iam-root-access-key-check" {
-  provider = aws.${baseline_provider_key}-${account_region}
-  name     = "iam-root-access-key-check"
+  provider                    = aws.${baseline_provider_key}-${account_region}
+  name                        = "iam-root-access-key-check"
   maximum_execution_frequency = "TwentyFour_Hours"
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "IAM_ROOT_ACCESS_KEY_CHECK"
   }
 
@@ -378,12 +378,12 @@ resource "aws_config_config_rule" "iam-root-access-key-check" {
 }
 
 resource "aws_config_config_rule" "iam-user-mfa-enabled" {
-  provider = aws.${baseline_provider_key}-${account_region}
-  name     = "iam-user-mfa-enabled"
+  provider                    = aws.${baseline_provider_key}-${account_region}
+  name                        = "iam-user-mfa-enabled"
   maximum_execution_frequency = "TwentyFour_Hours"
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "IAM_USER_MFA_ENABLED"
   }
 
@@ -393,16 +393,16 @@ resource "aws_config_config_rule" "iam-user-mfa-enabled" {
 }
 
 resource "aws_config_config_rule" "iam-user-unused-credentials-check" {
-  provider = aws.${baseline_provider_key}-${account_region}
-  name     = "iam-user-unused-credentials-check"
+  provider                    = aws.${baseline_provider_key}-${account_region}
+  name                        = "iam-user-unused-credentials-check"
   maximum_execution_frequency = "TwentyFour_Hours"
 
   input_parameters = jsonencode({
-    maxCredentialUsageAge: "30"
+    maxCredentialUsageAge : "30"
   })
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "IAM_USER_UNUSED_CREDENTIALS_CHECK"
   }
 
@@ -412,12 +412,12 @@ resource "aws_config_config_rule" "iam-user-unused-credentials-check" {
 }
 
 resource "aws_config_config_rule" "mfa-enabled-for-iam-console-access" {
-  provider = aws.${baseline_provider_key}-${account_region}
-  name     = "mfa-enabled-for-iam-console-access"
+  provider                    = aws.${baseline_provider_key}-${account_region}
+  name                        = "mfa-enabled-for-iam-console-access"
   maximum_execution_frequency = "TwentyFour_Hours"
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "MFA_ENABLED_FOR_IAM_CONSOLE_ACCESS"
   }
 
@@ -431,14 +431,14 @@ resource "aws_config_config_rule" "required-tags" {
   name     = "required-tags"
 
   input_parameters = jsonencode({
-    tag1Key: "business-unit",
-    tag2Key: "application",
-    tag3Key: "owner",
-    tag4Key: "is-production"
+    tag1Key : "business-unit",
+    tag2Key : "application",
+    tag3Key : "owner",
+    tag4Key : "is-production"
   })
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "REQUIRED_TAGS"
   }
 
@@ -448,12 +448,12 @@ resource "aws_config_config_rule" "required-tags" {
 }
 
 resource "aws_config_config_rule" "root-account-mfa-enabled" {
-  provider = aws.${baseline_provider_key}-${account_region}
-  name     = "root-account-mfa-enabled"
+  provider                    = aws.${baseline_provider_key}-${account_region}
+  name                        = "root-account-mfa-enabled"
   maximum_execution_frequency = "TwentyFour_Hours"
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "ROOT_ACCOUNT_MFA_ENABLED"
   }
 
@@ -467,7 +467,7 @@ resource "aws_config_config_rule" "s3-account-level-public-access-blocks" {
   name     = "s3-account-level-public-access-blocks"
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "S3_ACCOUNT_LEVEL_PUBLIC_ACCESS_BLOCKS"
   }
 
@@ -481,7 +481,7 @@ resource "aws_config_config_rule" "s3-bucket-public-read-prohibited" {
   name     = "s3-bucket-public-read-prohibited"
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "S3_BUCKET_PUBLIC_READ_PROHIBITED"
   }
 
@@ -495,7 +495,7 @@ resource "aws_config_config_rule" "s3-bucket-public-write-prohibited" {
   name     = "s3-bucket-public-write-prohibited"
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "S3_BUCKET_PUBLIC_WRITE_PROHIBITED"
   }
 
@@ -509,7 +509,7 @@ resource "aws_config_config_rule" "s3-bucket-server-side-encryption-enabled" {
   name     = "s3-bucket-server-side-encryption-enabled"
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"
   }
 
@@ -523,7 +523,7 @@ resource "aws_config_config_rule" "s3-bucket-ssl-requests-only" {
   name     = "s3-bucket-ssl-requests-only"
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "S3_BUCKET_SSL_REQUESTS_ONLY"
   }
 
@@ -533,12 +533,12 @@ resource "aws_config_config_rule" "s3-bucket-ssl-requests-only" {
 }
 
 resource "aws_config_config_rule" "securityhub-enabled" {
-  provider = aws.${baseline_provider_key}-${account_region}
-  name     = "securityhub-enabled"
+  provider                    = aws.${baseline_provider_key}-${account_region}
+  name                        = "securityhub-enabled"
   maximum_execution_frequency = "TwentyFour_Hours"
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "SECURITYHUB_ENABLED"
   }
 
@@ -552,7 +552,7 @@ resource "aws_config_config_rule" "sns-encrypted-kms" {
   name     = "sns-encrypted-kms"
 
   source {
-    owner = "AWS"
+    owner             = "AWS"
     source_identifier = "SNS_ENCRYPTED_KMS"
   }
 


### PR DESCRIPTION
This resolves spacing issues that causes `terraform fmt` via the `code-formatter` GitHub action to reformat generated files.