### PR TITLE
Enable IAM Access Analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+.terraform
+*.tfstate*

--- a/access-analyzer.tf
+++ b/access-analyzer.tf
@@ -1,0 +1,127 @@
+module "access-analyzer-ap-northeast-1" {
+  source = "./modules/access-analyzer"
+  providers = {
+    aws = aws.ap-northeast-1
+  }
+  tags = var.tags
+}
+
+module "access-analyzer-ap-northeast-2" {
+  source = "./modules/access-analyzer"
+  providers = {
+    aws = aws.ap-northeast-2
+  }
+  tags = var.tags
+}
+
+module "access-analyzer-ap-south-1" {
+  source = "./modules/access-analyzer"
+  providers = {
+    aws = aws.ap-south-1
+  }
+  tags = var.tags
+}
+
+module "access-analyzer-ap-southeast-1" {
+  source = "./modules/access-analyzer"
+  providers = {
+    aws = aws.ap-southeast-1
+  }
+  tags = var.tags
+}
+
+module "access-analyzer-ap-southeast-2" {
+  source = "./modules/access-analyzer"
+  providers = {
+    aws = aws.ap-southeast-2
+  }
+  tags = var.tags
+}
+
+module "access-analyzer-ca-central-1" {
+  source = "./modules/access-analyzer"
+  providers = {
+    aws = aws.ca-central-1
+  }
+  tags = var.tags
+}
+
+module "access-analyzer-eu-central-1" {
+  source = "./modules/access-analyzer"
+  providers = {
+    aws = aws.eu-central-1
+  }
+  tags = var.tags
+}
+
+module "access-analyzer-eu-north-1" {
+  source = "./modules/access-analyzer"
+  providers = {
+    aws = aws.eu-north-1
+  }
+  tags = var.tags
+}
+
+module "access-analyzer-eu-west-1" {
+  source = "./modules/access-analyzer"
+  providers = {
+    aws = aws.eu-west-1
+  }
+  tags = var.tags
+}
+
+module "access-analyzer-eu-west-2" {
+  source = "./modules/access-analyzer"
+  providers = {
+    aws = aws.eu-west-2
+  }
+  tags = var.tags
+}
+
+module "access-analyzer-eu-west-3" {
+  source = "./modules/access-analyzer"
+  providers = {
+    aws = aws.eu-west-3
+  }
+  tags = var.tags
+}
+
+module "access-analyzer-sa-east-1" {
+  source = "./modules/access-analyzer"
+  providers = {
+    aws = aws.sa-east-1
+  }
+  tags = var.tags
+}
+
+module "access-analyzer-us-east-1" {
+  source = "./modules/access-analyzer"
+  providers = {
+    aws = aws.us-east-1
+  }
+  tags = var.tags
+}
+
+module "access-analyzer-us-east-2" {
+  source = "./modules/access-analyzer"
+  providers = {
+    aws = aws.us-east-2
+  }
+  tags = var.tags
+}
+
+module "access-analyzer-us-west-1" {
+  source = "./modules/access-analyzer"
+  providers = {
+    aws = aws.us-west-1
+  }
+  tags = var.tags
+}
+
+module "access-analyzer-us-west-2" {
+  source = "./modules/access-analyzer"
+  providers = {
+    aws = aws.us-west-2
+  }
+  tags = var.tags
+}

--- a/modules/access-analyzer/main.tf
+++ b/modules/access-analyzer/main.tf
@@ -1,0 +1,5 @@
+resource "aws_accessanalyzer_analyzer" "default" {
+  analyzer_name = "analyzer"
+  type          = "ACCOUNT"
+  tags          = var.tags
+}

--- a/modules/access-analyzer/variables.tf
+++ b/modules/access-analyzer/variables.tf
@@ -1,0 +1,1 @@
+variable "tags" {}

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,67 @@
+provider "aws" {
+
+}
+
+provider "aws" {
+  alias = "ap-northeast-1"
+}
+
+provider "aws" {
+  alias = "ap-northeast-2"
+}
+
+provider "aws" {
+  alias = "ap-south-1"
+}
+
+provider "aws" {
+  alias = "ap-southeast-1"
+}
+
+provider "aws" {
+  alias = "ap-southeast-2"
+}
+
+provider "aws" {
+  alias = "ca-central-1"
+}
+
+provider "aws" {
+  alias = "eu-central-1"
+}
+
+provider "aws" {
+  alias = "eu-north-1"
+}
+
+provider "aws" {
+  alias = "eu-west-1"
+}
+
+provider "aws" {
+  alias = "eu-west-2"
+}
+
+provider "aws" {
+  alias = "eu-west-3"
+}
+
+provider "aws" {
+  alias = "sa-east-1"
+}
+
+provider "aws" {
+  alias = "us-east-1"
+}
+
+provider "aws" {
+  alias = "us-east-2"
+}
+
+provider "aws" {
+  alias = "us-west-1"
+}
+
+provider "aws" {
+  alias = "us-west-2"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,9 @@ variable "baseline_provider_key" {
   type        = string
   description = "A unique provider key to use for provider definitions"
 }
+
+variable "tags" {
+  type        = map
+  default     = {}
+  description = "Tags to apply to resources, where applicable"
+}


### PR DESCRIPTION
This enables IAM Access Analyzer is all 16 enabled-by-default regions in AWS.
