### PR TITLE
Explicitly show the Config module depends on the CloudTrail module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,4 +12,5 @@ module "config" {
     s3_bucket_id             = module.cloudtrail.s3_bucket_id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn
   }
+  depends_on = [module.cloudtrail]
 }


### PR DESCRIPTION
The Config module requires some CloudTrail outputs to correctly configure some rules. If `terraform apply`ied without depends_on, it throws an error due to them both being created asynchronously. This tells Terraform to wait for module.cloudtrail to be configured before configuring Config.