### PR TITLE
Configure IAM password policy to comply with CIS AWS Foundations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ module "cloudtrail" {
 module "iam" {
   source = "./modules/iam"
 }
-  
+
 module "support" {
   source = "./modules/support"
   tags   = var.tags

--- a/main.tf
+++ b/main.tf
@@ -2,3 +2,7 @@ module "cloudtrail" {
   source = "./modules/cloudtrail"
   tags   = var.tags
 }
+
+module "iam" {
+  source = "./modules/iam"
+}

--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -1,0 +1,14 @@
+# IAM
+
+This module configures the following:
+
+## IAM Password Policy
+The password policy set within this module complies with CIS AWS Foundations Benchmark v1.2.0, namely rules:
+
+- [x] [CIS 1.5 – Ensure IAM password policy requires at least one uppercase letter](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#cis-1.5-remediation)
+- [x] [CIS 1.6 – Ensure IAM password policy requires at least one lowercase letter](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#cis-1.6-remediation)
+- [x] [CIS 1.7 - Ensure IAM password policy requires at least one symbol](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#cis-1.7-remediation)
+- [x] [CIS 1.8 - Ensure IAM password policy requires at least one number](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#cis-1.8-remediation)
+- [x] [CIS 1.9 - Ensure IAM password policy requires a minimum length of 14 or greater](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#cis-1.9-remediation)
+- [x] [CIS 1.10 - Ensure IAM password policy prevents password reuse](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#cis-1.10-remediation)
+- [x] [CIS 1.11 - Ensure IAM password policy expires passwords within 90 days or less](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#cis-1.11-remediation)

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -1,0 +1,11 @@
+resource "aws_iam_account_password_policy" "default" {
+  allow_users_to_change_password = true
+  hard_expiry                    = false
+  max_password_age               = 90
+  minimum_password_length        = 14
+  password_reuse_prevention      = 24
+  require_lowercase_characters   = true
+  require_numbers                = true
+  require_symbols                = true
+  require_uppercase_characters   = true
+}


### PR DESCRIPTION
The password policy set within this module complies with CIS AWS Foundations Benchmark v1.2.0. It also allows us to centrally configure all the account password policies on the Modernisation Platform.