### PR TITLE
Create a role for Support service access

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,3 +2,8 @@ module "cloudtrail" {
   source = "./modules/cloudtrail"
   tags   = var.tags
 }
+
+module "support" {
+  source = "./modules/support"
+  tags   = var.tags
+}

--- a/modules/support/main.tf
+++ b/modules/support/main.tf
@@ -1,0 +1,26 @@
+data "aws_caller_identity" "current" {}
+
+# Create an IAM role for AWS Support service access
+resource "aws_iam_role" "support" {
+  name               = "support"
+  assume_role_policy = data.aws_iam_policy_document.assume-role-policy.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "assume-role-policy" {
+  version = "2012-10-17"
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "support" {
+  role       = aws_iam_role.support.id
+  policy_arn = "arn:aws:iam::aws:policy/AWSSupportAccess"
+}

--- a/modules/support/variables.tf
+++ b/modules/support/variables.tf
@@ -1,0 +1,4 @@
+variable "tags" {
+  type        = map
+  description = "Tags to apply to resources, where applicable"
+}


### PR DESCRIPTION
This creates an IAM role to allow access to the AWS Support service. It's useful for people without `AdminstratorAccess` or who have more restrictive access, so they can lodge any issues with the AWS Support service if needed.