### PR TITLE
Create standardised backup plans

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,8 @@
+module "backup" {
+  source = "./modules/backup"
+  tags   = var.tags
+}
+
 module "cloudtrail" {
   source = "./modules/cloudtrail"
   tags   = var.tags

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -1,0 +1,37 @@
+locals {
+  cold_storage_after = 30
+}
+
+resource "aws_backup_vault" "default" {
+  name = "everything"
+  tags = var.tags
+}
+
+resource "aws_backup_plan" "default" {
+  name = "backup-daily-cold-storage-monthly-retain-120-days"
+
+  rule {
+    rule_name         = "backup-daily-cold-storage-monthly-retain-120-days"
+    target_vault_name = aws_backup_vault.default.name
+    # Backup every day at 00:30am
+    schedule = "cron(30 0 * * ? *)"
+
+    # The lifecycle only supports EFS file system backups at present.
+    # There is a minimum amount of days a backup must be in cold storage (90 days)
+    # before being deleted.
+    # See: https://docs.aws.amazon.com/aws-backup/latest/devguide/API_Lifecycle.html
+    lifecycle {
+      cold_storage_after = local.cold_storage_after
+      delete_after       = (local.cold_storage_after + 90)
+    }
+  }
+
+  advanced_backup_setting {
+    backup_options = {
+      WindowsVSS = "enabled"
+    }
+    resource_type = "EC2"
+  }
+
+  tags = var.tags
+}

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -1,0 +1,4 @@
+variable "tags" {
+  type        = map
+  description = "Tags to apply to resources, where applicable"
+}


### PR DESCRIPTION
This creates a standardised backup vault and a default backup plan. We can add more plans as we onboard teams for their needs, so this just creates a small initial configuration.

This utilises [AWS Backup](https://aws.amazon.com/backup/).