### PR TITLE
Configure CloudTrail bucket logging and use modernisation-platform-terraform-s3-bucket module

### DIFF
--- a/modules/cloudtrail/outputs.tf
+++ b/modules/cloudtrail/outputs.tf
@@ -3,7 +3,7 @@ output "cloudwatch_log_group_arn" {
 }
 
 output "s3_bucket_id" {
-  value = aws_s3_bucket.cloudtrail.id
+  value = module.cloudtrail-bucket.bucket.id
 }
 
 output "sns_topic_arn" {


### PR DESCRIPTION
Requires ministryofjustice/modernisation-platform-terraform-s3-bucket#1.

This PR configures CloudTrail bucket logging and utilises the [ministryofjustice/modernisation-platform-terraform-s3-bucket](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket) module instead of creating S3 buckets directly. It will allow us to standardise attributes like `lifecycle` rules, enforcing SSL on every bucket, S3 encryption, etc. across the Modernisation Platform.