### PR TITLE
Enable bucket replication and introduce replication_region

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,18 @@ module "baselines" {
     aws.us-west-1      = aws.us-west-1
     aws.us-west-2      = aws.us-west-2
   }
-  root_account_id = "123456789"
-  tags            = {}
+  replication_region = "eu-west-2"
+  root_account_id    = "123456789"
+  tags               = {}
 }
 ```
 
 ## Inputs
-| Name            | Description                                                           | Type   | Default | Required |
-|:---------------:|:---------------------------------------------------------------------:|:------:|:-------:|----------|
-| root_account_id | AWS Organisations root account ID that this account should be part of | string |         | yes      |
-| tags            | Tags to apply to resources, where applicable                          | map    | {}      | no       |
+| Name               | Description                                                           | Type   | Default | Required |
+|:------------------:|:---------------------------------------------------------------------:|:------:|:-------:|----------|
+| replication_region | Region to replicate S3 buckets into                                   | string |         | yes      |
+| root_account_id    | AWS Organisations root account ID that this account should be part of | string |         | yes      |
+| tags               | Tags to apply to resources, where applicable                          | map    | {}      | no       |
 
 ## Outputs
 None

--- a/config.tf
+++ b/config.tf
@@ -96,10 +96,13 @@ resource "aws_iam_role_policy_attachment" "config-publish-policy" {
 
 # AWS Config: configure an S3 bucket
 module "config-bucket" {
-  source        = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket"
-  bucket_prefix = "config-"
-  bucket_policy = data.aws_iam_policy_document.config-s3-policy.json
-  tags          = var.tags
+  source               = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket"
+  bucket_policy        = data.aws_iam_policy_document.config-s3-policy.json
+  bucket_prefix        = "config-"
+  home_region          = data.aws_region.current.name
+  replication_region   = var.replication_region
+  replication_role_arn = module.s3-replication-role.role.arn
+  tags                 = var.tags
 }
 
 # AWS Config: bucket policy, and require secure transport
@@ -178,7 +181,7 @@ module "config-ap-northeast-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket_id
+    s3_bucket_id             = module.cloudtrail.s3_bucket.id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -195,7 +198,7 @@ module "config-ap-northeast-2" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket_id
+    s3_bucket_id             = module.cloudtrail.s3_bucket.id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -212,7 +215,7 @@ module "config-ap-south-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket_id
+    s3_bucket_id             = module.cloudtrail.s3_bucket.id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -229,7 +232,7 @@ module "config-ap-southeast-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket_id
+    s3_bucket_id             = module.cloudtrail.s3_bucket.id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -246,7 +249,7 @@ module "config-ap-southeast-2" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket_id
+    s3_bucket_id             = module.cloudtrail.s3_bucket.id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -263,7 +266,7 @@ module "config-ca-central-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket_id
+    s3_bucket_id             = module.cloudtrail.s3_bucket.id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -280,7 +283,7 @@ module "config-eu-central-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket_id
+    s3_bucket_id             = module.cloudtrail.s3_bucket.id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -297,7 +300,7 @@ module "config-eu-north-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket_id
+    s3_bucket_id             = module.cloudtrail.s3_bucket.id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -314,7 +317,7 @@ module "config-eu-west-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket_id
+    s3_bucket_id             = module.cloudtrail.s3_bucket.id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -331,7 +334,7 @@ module "config-eu-west-2" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket_id
+    s3_bucket_id             = module.cloudtrail.s3_bucket.id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -348,7 +351,7 @@ module "config-eu-west-3" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket_id
+    s3_bucket_id             = module.cloudtrail.s3_bucket.id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -365,7 +368,7 @@ module "config-sa-east-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket_id
+    s3_bucket_id             = module.cloudtrail.s3_bucket.id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -382,7 +385,7 @@ module "config-us-east-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket_id
+    s3_bucket_id             = module.cloudtrail.s3_bucket.id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -399,7 +402,7 @@ module "config-us-east-2" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket_id
+    s3_bucket_id             = module.cloudtrail.s3_bucket.id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -416,7 +419,7 @@ module "config-us-west-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket_id
+    s3_bucket_id             = module.cloudtrail.s3_bucket.id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -433,7 +436,7 @@ module "config-us-west-2" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket_id
+    s3_bucket_id             = module.cloudtrail.s3_bucket.id
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags

--- a/main.tf
+++ b/main.tf
@@ -4,8 +4,10 @@ module "backup" {
 }
 
 module "cloudtrail" {
-  source = "./modules/cloudtrail"
-  tags   = var.tags
+  source               = "./modules/cloudtrail"
+  replication_role_arn = module.s3-replication-role.role.arn
+  replication_region   = var.replication_region
+  tags                 = var.tags
 }
 
 module "iam" {
@@ -20,4 +22,14 @@ module "support" {
 module "securityhub-alarms" {
   source = "./modules/securityhub-alarms"
   tags   = var.tags
+}
+
+module "s3-replication-role" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role"
+  buckets = [
+    module.config-bucket.bucket.arn,
+    module.cloudtrail.s3_bucket.arn,
+    module.cloudtrail.log_bucket.arn
+  ]
+  tags = var.tags
 }

--- a/modules/cloudtrail/main.tf
+++ b/modules/cloudtrail/main.tf
@@ -102,16 +102,22 @@ module "cloudtrail-bucket" {
   bucket_prefix          = "cloudtrail-"
   custom_kms_key         = aws_kms_key.cloudtrail.arn
   enable_lifecycle_rules = true
+  home_region            = data.aws_region.current.name
   log_bucket             = module.cloudtrail-log-bucket.bucket.id
   log_prefix             = "cloudtrail/log"
+  replication_region     = var.replication_region
+  replication_role_arn   = var.replication_role_arn
   tags                   = var.tags
 }
 
 module "cloudtrail-log-bucket" {
-  source        = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket"
-  bucket_prefix = "log-bucket"
-  acl           = "log-delivery-write"
-  tags          = var.tags
+  source               = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket"
+  acl                  = "log-delivery-write"
+  bucket_prefix        = "log-bucket"
+  home_region          = data.aws_region.current.name
+  replication_region   = var.replication_region
+  replication_role_arn = var.replication_role_arn
+  tags                 = var.tags
 }
 
 # Extrapolated from:

--- a/modules/cloudtrail/outputs.tf
+++ b/modules/cloudtrail/outputs.tf
@@ -2,8 +2,12 @@ output "cloudwatch_log_group_arn" {
   value = aws_cloudwatch_log_group.cloudtrail.arn
 }
 
-output "s3_bucket_id" {
-  value = module.cloudtrail-bucket.bucket.id
+output "s3_bucket" {
+  value = module.cloudtrail-bucket.bucket
+}
+
+output "log_bucket" {
+  value = module.cloudtrail-log-bucket.bucket
 }
 
 output "sns_topic_arn" {

--- a/modules/cloudtrail/variables.tf
+++ b/modules/cloudtrail/variables.tf
@@ -1,1 +1,14 @@
-variable "tags" {}
+variable "replication_region" {
+  type        = string
+  description = "Region to replicate S3 buckets into"
+}
+
+variable "replication_role_arn" {
+  type        = string
+  description = "Role ARN for S3 replication"
+}
+
+variable "tags" {
+  type        = map
+  description = "Tags to apply to resources, where applicable"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "replication_region" {
+  type        = string
+  description = "Region to replicate S3 buckets into"
+}
+
 variable "root_account_id" {
   type        = string
   description = "The AWS Organisations root account ID that this account should be part of"


### PR DESCRIPTION
This PR introduces the variable `replication_region` and utilises [modernisation-platform-terraform-s3-bucket](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket) and [modernisation-platform-terraform-s3-bucket-replication-role](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role) to automatically replicate S3 buckets created within this module, including: `cloudtrail`, `cloudtrail-logs`, `config`.

It also repoints the `module.cloudtrail.s3_bucket_id` to be less granular and support all Terraform attributes, so `module.cloudtrail.s3_bucket_id` is now available from `module.cloudtrail.s3_bucket.bucket.id`.