### PR TITLE
Add more configurations to the README & update variable block descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Terraform module for enabling and configuring the [MoJ Security Guidance](https://ministryofjustice.github.io/security-guidance/baseline-aws-accounts/#baseline-for-amazon-web-services-accounts) baseline for AWS accounts, alongside some extra reasonable security, identity and compliance  services.
 
-## Enabled Security Guidance services
+## Enabled MoJ Security Guidance configurations
 - [ ] Security email setting
 - [x] GuardDuty
 - [x] CloudTrail
@@ -14,8 +14,13 @@ Terraform module for enabling and configuring the [MoJ Security Guidance](https:
 - [ ] World Access
 - [x] SecurityHub
 
-## Enabled Security, Identity and Compliance services
-- [x] IAM Access Analyzer
+## Other enabled configurations
+- [x] AWS Backup
+- [x] AWS IAM Access Analyzer
+- [x] AWS IAM password policy
+- [x] EBS encryption
+- [x] SecurityHub alarms
+- [x] VPC logging
 
 ## Usage
 ```

--- a/modules/access-analyzer/variables.tf
+++ b/modules/access-analyzer/variables.tf
@@ -1,1 +1,4 @@
-variable "tags" {}
+variable "tags" {
+  type        = map
+  description = "Tags to apply to resources, where applicable"
+}

--- a/modules/cloudtrail/variables.tf
+++ b/modules/cloudtrail/variables.tf
@@ -1,1 +1,4 @@
-variable "tags" {}
+variable "tags" {
+  type        = map
+  description = "Tags to apply to resources, where applicable"
+}

--- a/modules/guardduty/variables.tf
+++ b/modules/guardduty/variables.tf
@@ -1,1 +1,4 @@
-variable "tags" {}
+variable "tags" {
+  type        = map
+  description = "Tags to apply to resources, where applicable"
+}

--- a/modules/securityhub-alarms/variables.tf
+++ b/modules/securityhub-alarms/variables.tf
@@ -1,4 +1,4 @@
 variable "tags" {
-  description = "Tags to apply to resources, where applicable"
   type        = map
+  description = "Tags to apply to resources, where applicable"
 }


### PR DESCRIPTION
This adds some more services to the README that are configured as part of this module, alongside updating some stray `variable "tag"` blocks that didn't have descriptions.