### PR TITLE
Add usage for singular modules, and update versions.tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Terraform module for enabling and configuring the [MoJ Security Guidance](https:
 - [x] IAM Access Analyzer
 
 ## Usage
+### Using the whole module
 ```
 module "baselines" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines"
@@ -42,6 +43,15 @@ module "baselines" {
   }
   root_account_id = "123456789"
   tags            = {}
+}
+```
+
+### Using parts of the module
+You can specify submodules from this directory to use individually, by [setting the source with a double-slash](https://www.terraform.io/docs/modules/sources.html#modules-in-package-sub-directories) (`//`). Note that this only uses the module in the calling region, unless you specify different module blocks with other Terraform providers.
+
+```
+module "ebs-encryption" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines//modules/ebs"
 }
 ```
 

--- a/modules/access-analyzer/versions.tf
+++ b/modules/access-analyzer/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/backup/versions.tf
+++ b/modules/backup/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/cloudtrail/versions.tf
+++ b/modules/cloudtrail/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/config/versions.tf
+++ b/modules/config/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/ebs/versions.tf
+++ b/modules/ebs/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/guardduty/versions.tf
+++ b/modules/guardduty/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/iam/versions.tf
+++ b/modules/iam/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/securityhub-alarms/versions.tf
+++ b/modules/securityhub-alarms/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/securityhub/versions.tf
+++ b/modules/securityhub/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/support/versions.tf
+++ b/modules/support/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
This updates `versions.tf` so individual modules (such as `ebs`) can be used correctly (i.e. by enforcing the usage of Terraform 0.13), and updates the README showing how you can use singular modules.