### PR TITLE
Remove home_region, and use default caller region

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -99,7 +99,6 @@ module "config-bucket" {
   source               = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket"
   bucket_policy        = data.aws_iam_policy_document.config-s3-policy.json
   bucket_prefix        = "config-"
-  home_region          = data.aws_region.current.name
   replication_region   = var.replication_region
   replication_role_arn = module.s3-replication-role.role.arn
   tags                 = var.tags

--- a/modules/cloudtrail/main.tf
+++ b/modules/cloudtrail/main.tf
@@ -102,7 +102,6 @@ module "cloudtrail-bucket" {
   bucket_prefix          = "cloudtrail-"
   custom_kms_key         = aws_kms_key.cloudtrail.arn
   enable_lifecycle_rules = true
-  home_region            = data.aws_region.current.name
   log_bucket             = module.cloudtrail-log-bucket.bucket.id
   log_prefix             = "cloudtrail/log"
   replication_region     = var.replication_region
@@ -114,7 +113,6 @@ module "cloudtrail-log-bucket" {
   source               = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket"
   acl                  = "log-delivery-write"
   bucket_prefix        = "log-bucket"
-  home_region          = data.aws_region.current.name
   replication_region   = var.replication_region
   replication_role_arn = var.replication_role_arn
   tags                 = var.tags


### PR DESCRIPTION
Requires ministryofjustice/modernisation-platform-terraform-s3-bucket#3.

The modernisation-platform-terraform-s3-bucket infers the "home region" by using the callers region to configure the initial S3 bucket.