### PR TITLE
Switch to using provider declarations for S3 bucket regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,25 +28,25 @@ Terraform module for enabling and configuring the [MoJ Security Guidance](https:
 module "baselines" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines"
   providers = {
-    aws                = aws
-    aws.ap-northeast-1 = aws.ap-northeast-1
-    aws.ap-northeast-2 = aws.ap-northeast-2
-    aws.ap-south-1     = aws.ap-south-1
-    aws.ap-southeast-1 = aws.ap-southeast-1
-    aws.ap-southeast-2 = aws.ap-southeast-2
-    aws.ca-central-1   = aws.ca-central-1
-    aws.eu-central-1   = aws.eu-central-1
-    aws.eu-north-1     = aws.eu-north-1
-    aws.eu-west-1      = aws.eu-west-1
-    aws.eu-west-2      = aws.eu-west-2
-    aws.eu-west-3      = aws.eu-west-3
-    aws.sa-east-1      = aws.sa-east-1
-    aws.us-east-1      = aws.us-east-1
-    aws.us-east-2      = aws.us-east-2
-    aws.us-west-1      = aws.us-west-1
-    aws.us-west-2      = aws.us-west-2
+    aws                    = aws
+    aws.replication-region = aws.eu-west-2 # Region to replicate S3 buckets into
+    aws.ap-northeast-1     = aws.ap-northeast-1
+    aws.ap-northeast-2     = aws.ap-northeast-2
+    aws.ap-south-1         = aws.ap-south-1
+    aws.ap-southeast-1     = aws.ap-southeast-1
+    aws.ap-southeast-2     = aws.ap-southeast-2
+    aws.ca-central-1       = aws.ca-central-1
+    aws.eu-central-1       = aws.eu-central-1
+    aws.eu-north-1         = aws.eu-north-1
+    aws.eu-west-1          = aws.eu-west-1
+    aws.eu-west-2          = aws.eu-west-2
+    aws.eu-west-3          = aws.eu-west-3
+    aws.sa-east-1          = aws.sa-east-1
+    aws.us-east-1          = aws.us-east-1
+    aws.us-east-2          = aws.us-east-2
+    aws.us-west-1          = aws.us-west-1
+    aws.us-west-2          = aws.us-west-2
   }
-  replication_region = "eu-west-2"
   root_account_id    = "123456789"
   tags               = {}
 }
@@ -64,7 +64,6 @@ module "ebs-encryption" {
 ## Inputs
 | Name               | Description                                                           | Type   | Default | Required |
 |:------------------:|:---------------------------------------------------------------------:|:------:|:-------:|----------|
-| replication_region | Region to replicate S3 buckets into                                   | string |         | yes      |
 | root_account_id    | AWS Organisations root account ID that this account should be part of | string |         | yes      |
 | tags               | Tags to apply to resources, where applicable                          | map    | {}      | no       |
 

--- a/config.tf
+++ b/config.tf
@@ -96,11 +96,12 @@ resource "aws_iam_role_policy_attachment" "config-publish-policy" {
 
 # AWS Config: configure an S3 bucket
 module "config-bucket" {
-  source               = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket"
+  providers = {
+    aws.bucket-replication = aws.replication-region
+  }
   bucket_policy        = data.aws_iam_policy_document.config-s3-policy.json
   bucket_prefix        = "config-"
-  home_region          = data.aws_region.current.name
-  replication_region   = var.replication_region
   replication_role_arn = module.s3-replication-role.role.arn
   tags                 = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -4,9 +4,11 @@ module "backup" {
 }
 
 module "cloudtrail" {
-  source               = "./modules/cloudtrail"
+  source = "./modules/cloudtrail"
+  providers = {
+    aws.replication-region = aws.replication-region
+  }
   replication_role_arn = module.s3-replication-role.role.arn
-  replication_region   = var.replication_region
   tags                 = var.tags
 }
 

--- a/modules/cloudtrail/variables.tf
+++ b/modules/cloudtrail/variables.tf
@@ -1,8 +1,3 @@
-variable "replication_region" {
-  type        = string
-  description = "Region to replicate S3 buckets into"
-}
-
 variable "replication_role_arn" {
   type        = string
   description = "Role ARN for S3 replication"

--- a/providers.tf
+++ b/providers.tf
@@ -3,6 +3,10 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias = "replication-region"
+}
+
+provider "aws" {
   alias = "ap-northeast-1"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-variable "replication_region" {
-  type        = string
-  description = "Region to replicate S3 buckets into"
-}
-
 variable "root_account_id" {
   type        = string
   description = "The AWS Organisations root account ID that this account should be part of"


### PR DESCRIPTION
Requires ministryofjustice/modernisation-platform-terraform-s3-bucket#4.

This moves to using a `provider` declaration rather than a variable to configure regions as part of changes to the above module.