### PR TITLE
Add an IAM role and use AWS Backup selection to backup resources

### DIFF
--- a/backup.tf
+++ b/backup.tf
@@ -1,9 +1,36 @@
+/*
+  IAM role for AWS Backup
+*/
+resource "aws_iam_role" "backup" {
+  name               = "AWSBackup"
+  assume_role_policy = data.aws_iam_policy_document.backup-assume-role-policy.json
+}
+
+data "aws_iam_policy_document" "backup-assume-role-policy" {
+  version = "2012-10-17"
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["backup.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "backup" {
+  role       = aws_iam_role.backup.id
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}
+
 module "backup-ap-northeast-1" {
   source = "./modules/backup"
   providers = {
     aws = aws.ap-northeast-1
   }
-  tags = var.tags
+  iam_role_arn = aws_iam_role.backup.arn
+  tags         = var.tags
 }
 
 module "backup-ap-northeast-2" {
@@ -11,7 +38,8 @@ module "backup-ap-northeast-2" {
   providers = {
     aws = aws.ap-northeast-2
   }
-  tags = var.tags
+  iam_role_arn = aws_iam_role.backup.arn
+  tags         = var.tags
 }
 
 module "backup-ap-south-1" {
@@ -19,7 +47,8 @@ module "backup-ap-south-1" {
   providers = {
     aws = aws.ap-south-1
   }
-  tags = var.tags
+  iam_role_arn = aws_iam_role.backup.arn
+  tags         = var.tags
 }
 
 module "backup-ap-southeast-1" {
@@ -27,7 +56,8 @@ module "backup-ap-southeast-1" {
   providers = {
     aws = aws.ap-southeast-1
   }
-  tags = var.tags
+  iam_role_arn = aws_iam_role.backup.arn
+  tags         = var.tags
 }
 
 module "backup-ap-southeast-2" {
@@ -35,7 +65,8 @@ module "backup-ap-southeast-2" {
   providers = {
     aws = aws.ap-southeast-2
   }
-  tags = var.tags
+  iam_role_arn = aws_iam_role.backup.arn
+  tags         = var.tags
 }
 
 module "backup-ca-central-1" {
@@ -43,7 +74,8 @@ module "backup-ca-central-1" {
   providers = {
     aws = aws.ca-central-1
   }
-  tags = var.tags
+  iam_role_arn = aws_iam_role.backup.arn
+  tags         = var.tags
 }
 
 module "backup-eu-central-1" {
@@ -51,7 +83,8 @@ module "backup-eu-central-1" {
   providers = {
     aws = aws.eu-central-1
   }
-  tags = var.tags
+  iam_role_arn = aws_iam_role.backup.arn
+  tags         = var.tags
 }
 
 module "backup-eu-north-1" {
@@ -59,7 +92,8 @@ module "backup-eu-north-1" {
   providers = {
     aws = aws.eu-north-1
   }
-  tags = var.tags
+  iam_role_arn = aws_iam_role.backup.arn
+  tags         = var.tags
 }
 
 module "backup-eu-west-1" {
@@ -67,7 +101,8 @@ module "backup-eu-west-1" {
   providers = {
     aws = aws.eu-west-1
   }
-  tags = var.tags
+  iam_role_arn = aws_iam_role.backup.arn
+  tags         = var.tags
 }
 
 module "backup-eu-west-2" {
@@ -75,7 +110,8 @@ module "backup-eu-west-2" {
   providers = {
     aws = aws.eu-west-2
   }
-  tags = var.tags
+  iam_role_arn = aws_iam_role.backup.arn
+  tags         = var.tags
 }
 
 module "backup-eu-west-3" {
@@ -83,7 +119,8 @@ module "backup-eu-west-3" {
   providers = {
     aws = aws.eu-west-3
   }
-  tags = var.tags
+  iam_role_arn = aws_iam_role.backup.arn
+  tags         = var.tags
 }
 
 module "backup-sa-east-1" {
@@ -91,7 +128,8 @@ module "backup-sa-east-1" {
   providers = {
     aws = aws.sa-east-1
   }
-  tags = var.tags
+  iam_role_arn = aws_iam_role.backup.arn
+  tags         = var.tags
 }
 
 module "backup-us-east-1" {
@@ -99,7 +137,8 @@ module "backup-us-east-1" {
   providers = {
     aws = aws.us-east-1
   }
-  tags = var.tags
+  iam_role_arn = aws_iam_role.backup.arn
+  tags         = var.tags
 }
 
 module "backup-us-east-2" {
@@ -107,7 +146,8 @@ module "backup-us-east-2" {
   providers = {
     aws = aws.us-east-2
   }
-  tags = var.tags
+  iam_role_arn = aws_iam_role.backup.arn
+  tags         = var.tags
 }
 
 module "backup-us-west-1" {
@@ -115,7 +155,8 @@ module "backup-us-west-1" {
   providers = {
     aws = aws.us-west-1
   }
-  tags = var.tags
+  iam_role_arn = aws_iam_role.backup.arn
+  tags         = var.tags
 }
 
 module "backup-us-west-2" {
@@ -123,5 +164,6 @@ module "backup-us-west-2" {
   providers = {
     aws = aws.us-west-2
   }
-  tags = var.tags
+  iam_role_arn = aws_iam_role.backup.arn
+  tags         = var.tags
 }

--- a/config.tf
+++ b/config.tf
@@ -1,6 +1,3 @@
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
-
 # AWS Config: configure an IAM role
 resource "aws_iam_role" "config" {
   name               = "AWSConfig"

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,6 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
 module "cloudtrail" {
   source = "./modules/cloudtrail"
   providers = {

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -1,3 +1,8 @@
+variable "iam_role_arn" {
+  type        = string
+  description = "IAM role ARN for the AWS Backup service role"
+}
+
 variable "tags" {
   type        = map
   description = "Tags to apply to resources, where applicable"


### PR DESCRIPTION
This creates an IAM role for automated Backups and configures AWS Backup selections to always backup databases tagged with `is-production: true`.

Resolves ministryofjustice/modernisation-platform#94.