### PR TITLE
Make tags optional across every submodule

### DIFF
--- a/modules/access-analyzer/variables.tf
+++ b/modules/access-analyzer/variables.tf
@@ -1,5 +1,5 @@
 variable "tags" {
-  type        = map
-  description = "Tags to apply to resources, where applicable"
   default     = {}
+  description = "Tags to apply to resources, where applicable"
+  type        = map
 }

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -4,6 +4,7 @@ variable "iam_role_arn" {
 }
 
 variable "tags" {
-  type        = map
+  default     = {}
   description = "Tags to apply to resources, where applicable"
+  type        = map
 }

--- a/modules/cloudtrail/variables.tf
+++ b/modules/cloudtrail/variables.tf
@@ -4,6 +4,7 @@ variable "replication_role_arn" {
 }
 
 variable "tags" {
-  type        = map
+  default     = {}
   description = "Tags to apply to resources, where applicable"
+  type        = map
 }

--- a/modules/config/variables.tf
+++ b/modules/config/variables.tf
@@ -24,6 +24,7 @@ variable "home_region" {
 }
 
 variable "tags" {
-  type        = map
+  default     = {}
   description = "Tags to apply to resources, where applicable"
+  type        = map
 }

--- a/modules/guardduty/variables.tf
+++ b/modules/guardduty/variables.tf
@@ -1,5 +1,5 @@
 variable "tags" {
-  type        = map
-  description = "Tags to apply to resources, where applicable"
   default     = {}
+  description = "Tags to apply to resources, where applicable"
+  type        = map
 }

--- a/modules/securityhub-alarms/variables.tf
+++ b/modules/securityhub-alarms/variables.tf
@@ -1,4 +1,5 @@
 variable "tags" {
-  type        = map
+  default     = {}
   description = "Tags to apply to resources, where applicable"
+  type        = map
 }

--- a/modules/support/variables.tf
+++ b/modules/support/variables.tf
@@ -1,4 +1,5 @@
 variable "tags" {
-  type        = map
+  default     = {}
   description = "Tags to apply to resources, where applicable"
+  type        = map
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -4,6 +4,7 @@ variable "iam_role_arn" {
 }
 
 variable "tags" {
-  type        = map
+  default     = {}
   description = "Tags to apply to resources, where applicable"
+  type        = map
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "root_account_id" {
 }
 
 variable "tags" {
-  type        = map
   default     = {}
   description = "Tags to apply to resources, where applicable"
+  type        = map
 }


### PR DESCRIPTION
This makes tags optional (by providing a default empty map `{}`) for all submodules. Resolves a bug where if you used a submodule and didn't provide tags, it would fail.