### PR TITLE
Explicitly depend on a whole module to resolve a racecase between CloudTrail and the CloudTrail S3 bucket

### DIFF
--- a/modules/cloudtrail/main.tf
+++ b/modules/cloudtrail/main.tf
@@ -35,6 +35,19 @@ resource "aws_cloudtrail" "cloudtrail" {
   }
 
   tags = var.tags
+
+  # Due to the nature of transistive dependencies, we need to wait for the whole
+  # module (including bucket policies) to finish before creating a CloudTrail trail.
+  #
+  # Even though this resource depends on "module.cloudtrail-bucket.bucket.id", which is an output
+  # of the cloudtrail-bucket module, once the bucket ID is evaluated, Terraform will start to create
+  # this resource even if other resources in the module haven't finished yet.
+  #
+  # This creates a race-case between this resource, and the policy on the bucket, which is
+  # created inside the module. By depending explicitly on the whole module, Terraform will wait
+  # until all resources have been created: including the bucket policy, which this CloudTrail resource
+  # requires before creation.
+  depends_on = [module.cloudtrail-bucket]
 }
 
 # IAM role for CloudTrail


### PR DESCRIPTION
Due to the nature of transistive dependencies, we need to wait for the whole module (including bucket policies) to finish before creating a CloudTrail trail.

Even though this resource depends on "module.cloudtrail-bucket.bucket.id", which is an output of the cloudtrail-bucket module, once the bucket ID is evaluated, Terraform will start to create this resource even if other resources in the module haven't finished yet.

This creates a race-case between this resource, and the policy on the bucket, which is created inside the module. By depending explicitly on the whole module, Terraform will wait until all resources have been created: including the bucket policy, which this CloudTrail resource requires before creation.

This is the issue described in ministryofjustice/modernisation-platform#143, where CloudTrail can't be provisioned (unless you run `terraform apply` twice), which means SecurityHub alarms (which rely on CloudTrail) also fail to be provisioned.