### PR TITLE
Add missing version constraints

### DIFF
--- a/modules/access-analyzer/versions.tf
+++ b/modules/access-analyzer/versions.tf
@@ -1,8 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
+  required_version = ">= 0.13"
 }

--- a/modules/backup/versions.tf
+++ b/modules/backup/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
   required_version = ">= 0.13"

--- a/modules/cloudtrail/versions.tf
+++ b/modules/cloudtrail/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
   required_version = ">= 0.13"

--- a/modules/config/versions.tf
+++ b/modules/config/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
   required_version = ">= 0.13"

--- a/modules/ebs/versions.tf
+++ b/modules/ebs/versions.tf
@@ -1,8 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
+  required_version = ">= 0.13"
 }

--- a/modules/guardduty/versions.tf
+++ b/modules/guardduty/versions.tf
@@ -1,8 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
+  required_version = ">= 0.13"
 }

--- a/modules/iam/versions.tf
+++ b/modules/iam/versions.tf
@@ -1,8 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
+  required_version = ">= 0.13"
 }

--- a/modules/securityhub-alarms/versions.tf
+++ b/modules/securityhub-alarms/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
   required_version = ">= 0.13"

--- a/modules/securityhub/versions.tf
+++ b/modules/securityhub/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
   required_version = ">= 0.13"

--- a/modules/support/versions.tf
+++ b/modules/support/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
   required_version = ">= 0.13"

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
   required_version = ">= 0.13"

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
This PR adds missing version constraints for the `aws` provider.

Preparation work as part of ministryofjustice/modernisation-platform#72.