### PR TITLE
Pin Terraform modules to their GitHub release versions

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -99,7 +99,7 @@ resource "aws_iam_role_policy_attachment" "config-publish-policy" {
 
 # AWS Config: configure an S3 bucket
 module "config-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v1.0.0"
   providers = {
     aws.bucket-replication = aws.replication-region
   }

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ module "securityhub-alarms" {
 }
 
 module "s3-replication-role" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role?ref=v1.0.0"
   buckets = [
     module.config-bucket.bucket.arn,
     module.cloudtrail.s3_bucket.arn,

--- a/modules/cloudtrail/main.tf
+++ b/modules/cloudtrail/main.tf
@@ -113,7 +113,7 @@ resource "aws_cloudwatch_log_stream" "cloudtrail-stream" {
 
 # AWS CloudTrail: configure an S3 bucket
 module "cloudtrail-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v1.0.0"
   providers = {
     aws.bucket-replication = aws.replication-region
   }
@@ -129,7 +129,7 @@ module "cloudtrail-bucket" {
 }
 
 module "cloudtrail-log-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v1.0.0"
   providers = {
     aws.bucket-replication = aws.replication-region
   }

--- a/modules/config/main.tf
+++ b/modules/config/main.tf
@@ -1,4 +1,3 @@
-data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 # Enable AWS Config


### PR DESCRIPTION
This PR pins Terraform modules to their latest GitHub release as part of ministryofjustice/modernisation-platform#72.

It also removes an unused data call for the caller identity (`aws_caller_identity`).