### PR TITLE
Add missing output descriptions for CloudTrail and Config

### DIFF
--- a/modules/cloudtrail/outputs.tf
+++ b/modules/cloudtrail/outputs.tf
@@ -1,15 +1,19 @@
 output "cloudwatch_log_group_arn" {
-  value = aws_cloudwatch_log_group.cloudtrail.arn
+  value       = aws_cloudwatch_log_group.cloudtrail.arn
+  description = "CloudTrail CloudWatch log group ARN"
 }
 
 output "log_bucket" {
-  value = module.cloudtrail-log-bucket.bucket
+  value       = module.cloudtrail-log-bucket.bucket
+  description = "Direct aws_s3_bucket resource with all attributes"
 }
 
 output "s3_bucket" {
-  value = module.cloudtrail-bucket.bucket
+  value       = module.cloudtrail-bucket.bucket
+  description = "Direct aws_s3_bucket resource with all attributes"
 }
 
 output "sns_topic_arn" {
-  value = aws_sns_topic.cloudtrail.arn
+  value       = aws_sns_topic.cloudtrail.arn
+  description = "CloudTrail SNS topic ARN"
 }

--- a/modules/config/outputs.tf
+++ b/modules/config/outputs.tf
@@ -1,3 +1,4 @@
 output "sns_topic_arn" {
-  value = aws_sns_topic.default.arn
+  value       = aws_sns_topic.default.arn
+  description = "Config SNS topic ARN"
 }


### PR DESCRIPTION
This PR adds missing output descriptions for submodules CloudTrail and Config.

Preparation work as part of ministryofjustice/modernisation-platform#72.