### PR TITLE
Fix baselines fail on first run due to dependancy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,10 @@ module "support" {
 
 module "securityhub-alarms" {
   source = "./modules/securityhub-alarms"
-  tags   = var.tags
+
+  depends_on = [module.cloudtrail]
+
+  tags = var.tags
 }
 
 module "s3-replication-role" {

--- a/variables.tf
+++ b/variables.tf
@@ -50,4 +50,3 @@ variable "enabled_vpc_regions" {
   description = "Regions to enable default VPC configuration and VPC Flow Logs in"
   type        = list(string)
 }
-


### PR DESCRIPTION
Currently the baselines fail on first run for a new account with the
error -

```
Error: Creating/Updating CloudWatch Log Metric Filter failed: ResourceNotFoundException: The specified log group does not exist.

  with module.baselines.module.securityhub-alarms.aws_cloudwatch_log_metric_filter.unauthorised-api-calls,
  on .terraform/modules/baselines/modules/securityhub-alarms/main.tf line 54, in resource "aws_cloudwatch_log_metric_filter" "unauthorised-api-calls":
  54: resource "aws_cloudwatch_log_metric_filter" "unauthorised-api-calls" {
```

This fails because the log group "cloudtrail" has not yet been created.
When creating the log group the only output available is ARN, and the
metric filter needs the log group name so this has been hard coded. It
is possible to manipulate the ARN to get the name, but this adds
complexity to the code just to achieve the dependancy. The simpler way
is adding a depends_on.