### PR TITLE
update-secure-baseline-module

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -99,14 +99,56 @@ resource "aws_iam_role_policy_attachment" "config-publish-policy" {
 
 # AWS Config: configure an S3 bucket
 module "config-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v2.0.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v3.0.0"
 
   providers = {
     aws.bucket-replication = aws.replication-region
   }
+  replication_enabled  = false
   bucket_policy        = data.aws_iam_policy_document.config-s3-policy.json
   bucket_prefix        = "config-"
-  replication_role_arn = module.s3-replication-role.role.arn
+
+  lifecycle_rule = [
+    {
+      id      = "main"
+      enabled = true
+      prefix  = ""
+
+      tags = {
+        rule      = "log"
+        autoclean = "true"
+      }
+
+      transition = [
+        {
+          days          = 90
+          storage_class = "STANDARD_IA"
+          }, {
+          days          = 365
+          storage_class = "GLACIER"
+        }
+      ]
+
+      expiration = {
+        days = 730
+      }
+
+      noncurrent_version_transition = [
+        {
+          days          = 90
+          storage_class = "STANDARD_IA"
+          }, {
+          days          = 365
+          storage_class = "GLACIER"
+        }
+      ]
+
+      noncurrent_version_expiration = {
+        days = 730
+      }
+    }
+  ]
+
   tags                 = var.tags
 }
 
@@ -188,7 +230,7 @@ module "config-ap-northeast-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket.id
+    s3_bucket_id             = local.cloudtrail_bucket
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -207,7 +249,7 @@ module "config-ap-northeast-2" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket.id
+    s3_bucket_id             = local.cloudtrail_bucket
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -226,7 +268,7 @@ module "config-ap-south-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket.id
+    s3_bucket_id             = local.cloudtrail_bucket
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -245,7 +287,7 @@ module "config-ap-southeast-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket.id
+    s3_bucket_id             = local.cloudtrail_bucket
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -264,7 +306,7 @@ module "config-ap-southeast-2" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket.id
+    s3_bucket_id             = local.cloudtrail_bucket
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -283,7 +325,7 @@ module "config-ca-central-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket.id
+    s3_bucket_id             = local.cloudtrail_bucket
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -302,7 +344,7 @@ module "config-eu-central-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket.id
+    s3_bucket_id             = local.cloudtrail_bucket
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -321,7 +363,7 @@ module "config-eu-north-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket.id
+    s3_bucket_id             = local.cloudtrail_bucket
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -340,7 +382,7 @@ module "config-eu-west-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket.id
+    s3_bucket_id             = local.cloudtrail_bucket
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -359,7 +401,7 @@ module "config-eu-west-2" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket.id
+    s3_bucket_id             = local.cloudtrail_bucket
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -378,7 +420,7 @@ module "config-eu-west-3" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket.id
+    s3_bucket_id             = local.cloudtrail_bucket
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -397,7 +439,7 @@ module "config-sa-east-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket.id
+    s3_bucket_id             = local.cloudtrail_bucket
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -416,7 +458,7 @@ module "config-us-east-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket.id
+    s3_bucket_id             = local.cloudtrail_bucket
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -435,7 +477,7 @@ module "config-us-east-2" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket.id
+    s3_bucket_id             = local.cloudtrail_bucket
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -454,7 +496,7 @@ module "config-us-west-1" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket.id
+    s3_bucket_id             = local.cloudtrail_bucket
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags
@@ -473,7 +515,7 @@ module "config-us-west-2" {
   home_region     = data.aws_region.current.name
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
-    s3_bucket_id             = module.cloudtrail.s3_bucket.id
+    s3_bucket_id             = local.cloudtrail_bucket
     sns_topic_arn            = module.cloudtrail.sns_topic_arn,
   }
   tags = var.tags

--- a/config.tf
+++ b/config.tf
@@ -104,9 +104,9 @@ module "config-bucket" {
   providers = {
     aws.bucket-replication = aws.replication-region
   }
-  replication_enabled  = false
-  bucket_policy        = data.aws_iam_policy_document.config-s3-policy.json
-  bucket_prefix        = "config-"
+  replication_enabled = false
+  bucket_policy       = data.aws_iam_policy_document.config-s3-policy.json
+  bucket_prefix       = "config-"
 
   lifecycle_rule = [
     {
@@ -149,7 +149,7 @@ module "config-bucket" {
     }
   ]
 
-  tags                 = var.tags
+  tags = var.tags
 }
 
 # AWS Config: bucket policy, and require secure transport

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,6 @@
 locals {
   enabled     = toset(["enabled"])
   not_enabled = toset([])
+  cloudtrail_bucket   = "modernisation-platform-logs-cloudtrail"
+
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  enabled     = toset(["enabled"])
-  not_enabled = toset([])
-  cloudtrail_bucket   = "modernisation-platform-logs-cloudtrail"
+  enabled           = toset(["enabled"])
+  not_enabled       = toset([])
+  cloudtrail_bucket = "modernisation-platform-logs-cloudtrail"
 
 }

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,9 @@ module "cloudtrail" {
   providers = {
     aws.replication-region = aws.replication-region
   }
-  replication_role_arn = module.s3-replication-role.role.arn
+  cloudtrail_kms_key = var.cloudtrail_kms_key
+  cloudtrail_bucket  = local.cloudtrail_bucket
+  # replication_role_arn = module.s3-replication-role.role.arn
   tags                 = var.tags
 }
 
@@ -27,12 +29,10 @@ module "securityhub-alarms" {
   tags = var.tags
 }
 
-module "s3-replication-role" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role?ref=v1.0.0"
-  buckets = [
-    module.config-bucket.bucket.arn,
-    module.cloudtrail.s3_bucket.arn,
-    module.cloudtrail.log_bucket.arn
-  ]
-  tags = var.tags
-}
+# module "s3-replication-role" {
+#   source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role?ref=v1.0.0"
+#   buckets = [
+#     module.config-bucket.bucket.arn
+#   ]
+#   tags = var.tags
+# }

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "cloudtrail" {
   cloudtrail_kms_key = var.cloudtrail_kms_key
   cloudtrail_bucket  = local.cloudtrail_bucket
   # replication_role_arn = module.s3-replication-role.role.arn
-  tags                 = var.tags
+  tags = var.tags
 }
 
 module "iam" {

--- a/modules/cloudtrail/README.md
+++ b/modules/cloudtrail/README.md
@@ -11,10 +11,11 @@ module "cloudtrail" {
 ```
 
 ## Inputs
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|----------|
-| replication_role_arn | Role ARN for S3 replication | string | | yes |
-| tags | Tags to apply to resources | map | {} | no |
+| Name                 | Description                 | Type   | Default | Required |
+|----------------------|-----------------------------|--------|---------|----------|
+| replication_role_arn | Role ARN for S3 replication | string |         | optional |
+| cloudtrail_bucket    | Centralised bucket name     | string |         | yes      |
+| tags                 | Tags to apply to resources  | map    | {}      | no       |
 
 ## Outputs
 | Name | Description | Sensitive |

--- a/modules/cloudtrail/outputs.tf
+++ b/modules/cloudtrail/outputs.tf
@@ -3,15 +3,15 @@ output "cloudwatch_log_group_arn" {
   description = "CloudTrail CloudWatch log group ARN"
 }
 
-output "log_bucket" {
-  value       = module.cloudtrail-log-bucket.bucket
-  description = "Direct aws_s3_bucket resource with all attributes"
-}
+# output "log_bucket" {
+#   value       = module.cloudtrail-log-bucket.bucket
+#   description = "Direct aws_s3_bucket resource with all attributes"
+# }
 
-output "s3_bucket" {
-  value       = module.cloudtrail-bucket.bucket
-  description = "Direct aws_s3_bucket resource with all attributes"
-}
+# output "s3_bucket" {
+#   value       = module.cloudtrail-bucket.bucket
+#   description = "Direct aws_s3_bucket resource with all attributes"
+# }
 
 output "sns_topic_arn" {
   value       = aws_sns_topic.cloudtrail.arn

--- a/modules/cloudtrail/variables.tf
+++ b/modules/cloudtrail/variables.tf
@@ -1,8 +1,17 @@
-variable "replication_role_arn" {
+# variable "replication_role_arn" {
+#   type        = string
+#   description = "Role ARN for S3 replication"
+# }
+
+variable "cloudtrail_kms_key" {
+  description = "Arn of kms key used for cloudtrail logs"
   type        = string
-  description = "Role ARN for S3 replication"
 }
 
+variable "cloudtrail_bucket" {
+  description = "Name of centralised Cloudtrail bucket"
+  type        = string
+}
 variable "tags" {
   default     = {}
   description = "Tags to apply to resources, where applicable"

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,8 @@ variable "enabled_vpc_regions" {
   description = "Regions to enable default VPC configuration and VPC Flow Logs in"
   type        = list(string)
 }
+
+variable "cloudtrail_kms_key" {
+  description = "Arn of kms key used for cloudtrail logs"
+  type        = string
+}


### PR DESCRIPTION
- amend AWS-Config code to remove replication bucket and point CloudTrail at
  centralised bucket
- bucket replication is now optional
- add variable for common KMS key from logging account
- comment out local bucket creation code
- comment out bucket arns in output.tf file

This change is required to centralise the output of CloudTrail Logs to
an S3 Bucket in the core-logging account. This will enable simplified
management and cross account reporting