### PR TITLE
Fix cloudtrail sns topic policy dependancy

### DIFF
--- a/modules/cloudtrail/main.tf
+++ b/modules/cloudtrail/main.tf
@@ -30,19 +30,10 @@ resource "aws_cloudtrail" "cloudtrail" {
     }
   }
 
-  tags = var.tags
+  # wait for sns topic policy to be attached 
+  depends_on = [aws_sns_topic_policy.cloudtrail]
 
-  # Due to the nature of transistive dependencies, we need to wait for the whole
-  # module (including bucket policies) to finish before creating a CloudTrail trail.
-  #
-  # Even though this resource depends on "module.cloudtrail-bucket.bucket.id", which is an output
-  # of the cloudtrail-bucket module, once the bucket ID is evaluated, Terraform will start to create
-  # this resource even if other resources in the module haven't finished yet.
-  #
-  # This creates a race-case between this resource, and the policy on the bucket, which is
-  # created inside the module. By depending explicitly on the whole module, Terraform will wait
-  # until all resources have been created: including the bucket policy, which this CloudTrail resource
-  # requires before creation.
+  tags = var.tags
 }
 
 # IAM role for CloudTrail


### PR DESCRIPTION
We currently get the following error message on first run of the
baseline:
```
Error: Error creating CloudTrail: InsufficientSnsTopicPolicyException: SNS Topic does not exist or the topic policy is incorrect!

  with module.baselines.module.cloudtrail.aws_cloudtrail.cloudtrail,
  on .terraform/modules/baselines/modules/cloudtrail/main.tf line 11, in resource "aws_cloudtrail" "cloudtrail":
  11: resource "aws_cloudtrail" "cloudtrail" {
```

I believe this is because the policy has not yet been attached to the
SNS topic, this change adds an explicit dependancy.

Also removed a confusing comment that referred to a previous depends on that no longer exists.

Fixes https://github.com/ministryofjustice/modernisation-platform/issues/1013