### PR TITLE
Remove controls around MFA

### DIFF
--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -83,7 +83,7 @@ resource "aws_cloudwatch_metric_alarm" "unauthorised-api-calls" {
 # 3.2 - Ensure a log metric filter and alarm exist for Management Console sign-in without MFA
 resource "aws_cloudwatch_log_metric_filter" "sign-in-without-mfa" {
   name           = "sign-in-without-mfa"
-  pattern        = "{($.eventName=\"ConsoleLogin\") && ($.additionalEventData.MFAUsed !=\"Yes\")}"
+  pattern        = "{($.eventName=\"ConsoleLogin\") && ($.additionalEventData.MFAUsed !=\"Yes\") && ($.userIdentity.type =\"IAMUser\") && ($.responseElements.ConsoleLogin = \"Success\") }"
   log_group_name = "cloudtrail"
 
   metric_transformation {

--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -1,4 +1,5 @@
 data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
 
 # Enable SecurityHub
 resource "aws_securityhub_account" "default" {}
@@ -19,4 +20,48 @@ resource "aws_securityhub_standards_subscription" "cis" {
 resource "aws_securityhub_standards_subscription" "pci" {
   standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/pci-dss/v/3.2.1"
   depends_on    = [aws_securityhub_account.default]
+}
+
+# Disabled standard controls - controls that we are not using as we have other mitigating factors in place
+# Disable security hub control, security hub currently doesn't cater for SSO log in with MFA from the SSO provider
+resource "aws_securityhub_standards_control" "cis_disable_mfa_metric_and_alarm" {
+  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/cis-aws-foundations-benchmark/v/1.2.0/3.2"
+  control_status        = "DISABLED"
+  disabled_reason       = "MFA from single sign on not supported currently"
+  depends_on            = [aws_securityhub_account.default]
+}
+
+resource "aws_securityhub_standards_control" "cis_disable_ensure_hardware_mfa_for_root" {
+  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/cis-aws-foundations-benchmark/v/1.2.0/1.14"
+  control_status        = "DISABLED"
+  disabled_reason       = "Root login actions prevented with SCPs"
+  depends_on            = [aws_securityhub_account.default]
+}
+
+resource "aws_securityhub_standards_control" "cis_disable_ensure_mfa_for_root" {
+  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/cis-aws-foundations-benchmark/v/1.2.0/1.13"
+  control_status        = "DISABLED"
+  disabled_reason       = "Root login actions prevented with SCPs"
+  depends_on            = [aws_securityhub_account.default]
+}
+
+resource "aws_securityhub_standards_control" "aws_disable_ensure_hardware_mfa_for_root" {
+  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/aws-foundational-security-best-practices/v/1.0.0/IAM.6"
+  control_status        = "DISABLED"
+  disabled_reason       = "Root login actions prevented with SCPs"
+  depends_on            = [aws_securityhub_account.default]
+}
+
+resource "aws_securityhub_standards_control" "pci_disable_ensure_hardware_mfa_for_root" {
+  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/pci-dss/v/3.2.1/PCI.IAM.4"
+  control_status        = "DISABLED"
+  disabled_reason       = "Root login actions prevented with SCPs"
+  depends_on            = [aws_securityhub_account.default]
+}
+
+resource "aws_securityhub_standards_control" "pci_disable_ensure_mfa_for_root" {
+  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/pci-dss/v/3.2.1/PCI.IAM.5"
+  control_status        = "DISABLED"
+  disabled_reason       = "Root login actions prevented with SCPs"
+  depends_on            = [aws_securityhub_account.default]
 }


### PR DESCRIPTION
Controls around hardware MFA and MFA for root users is not needed as we
have implemented SCPs which prevent the root user from performing any
actions when logged in.

Also disabling the MFA metric and alarm control as SSO users are using MFA with
the identity provider, but this is not recognised by security hub
currently. The alarm is adjusted to ignore SSO users without MFA.