### PR TITLE
Fix dependancy with security hub controls

### DIFF
--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -28,40 +28,40 @@ resource "aws_securityhub_standards_control" "cis_disable_mfa_metric_and_alarm" 
   standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/cis-aws-foundations-benchmark/v/1.2.0/3.2"
   control_status        = "DISABLED"
   disabled_reason       = "MFA from single sign on not supported currently"
-  depends_on            = [aws_securityhub_account.default]
+  depends_on            = [aws_securityhub_standards_subscription.cis]
 }
 
 resource "aws_securityhub_standards_control" "cis_disable_ensure_hardware_mfa_for_root" {
   standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/cis-aws-foundations-benchmark/v/1.2.0/1.14"
   control_status        = "DISABLED"
   disabled_reason       = "Root login actions prevented with SCPs"
-  depends_on            = [aws_securityhub_account.default]
+  depends_on            = [aws_securityhub_standards_subscription.cis]
 }
 
 resource "aws_securityhub_standards_control" "cis_disable_ensure_mfa_for_root" {
   standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/cis-aws-foundations-benchmark/v/1.2.0/1.13"
   control_status        = "DISABLED"
   disabled_reason       = "Root login actions prevented with SCPs"
-  depends_on            = [aws_securityhub_account.default]
+  depends_on            = [aws_securityhub_standards_subscription.cis]
 }
 
 resource "aws_securityhub_standards_control" "aws_disable_ensure_hardware_mfa_for_root" {
   standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/aws-foundational-security-best-practices/v/1.0.0/IAM.6"
   control_status        = "DISABLED"
   disabled_reason       = "Root login actions prevented with SCPs"
-  depends_on            = [aws_securityhub_account.default]
+  depends_on            = [aws_securityhub_standards_subscription.aws-foundational]
 }
 
 resource "aws_securityhub_standards_control" "pci_disable_ensure_hardware_mfa_for_root" {
   standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/pci-dss/v/3.2.1/PCI.IAM.4"
   control_status        = "DISABLED"
   disabled_reason       = "Root login actions prevented with SCPs"
-  depends_on            = [aws_securityhub_account.default]
+  depends_on            = [aws_securityhub_standards_subscription.pci]
 }
 
 resource "aws_securityhub_standards_control" "pci_disable_ensure_mfa_for_root" {
   standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/pci-dss/v/3.2.1/PCI.IAM.5"
   control_status        = "DISABLED"
   disabled_reason       = "Root login actions prevented with SCPs"
-  depends_on            = [aws_securityhub_account.default]
+  depends_on            = [aws_securityhub_standards_subscription.pci]
 }


### PR DESCRIPTION
The following error was occuring -

```
Error: error updating Security Hub Standards Control
(arn:aws:securityhub:us-east-1:532211371847:control/pci-dss/v/3.2.1/PCI.IAM.5):
ResourceNotFoundException: StandardsControl not found
```

This was due to the standards not being in place yet, this change puts a
dependancy on the standard being created.