### PR TITLE
Explicitly define control_finding_generator

### DIFF
--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -2,7 +2,9 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 # Enable SecurityHub
-resource "aws_securityhub_account" "default" {}
+resource "aws_securityhub_account" "default" {
+  control_finding_generator = "STANDARD_CONTROL"
+}
 
 # Enable Standard: AWS Foundational Security Best Practices
 resource "aws_securityhub_standards_subscription" "aws-foundational" {


### PR DESCRIPTION
In the tfprovider-aws4.64.0 update the default for control_finding_generator is set to `SECURITY_CONTROL`.

This is different to what we have set at the org level, so we are now getting errors on applies -

```
  # module.baselines-modernisation-platform.module.securityhub-eu-central-1["enabled"].aws_securityhub_account.default will be updated in-place
  ~ resource "aws_securityhub_account" "default" {
      ~ control_finding_generator = "STANDARD_CONTROL" -> "SECURITY_CONTROL"
        id                        = "***"
        # (3 unchanged attributes hidden)
    }
```

Because this setting is controlled at the org level we do not have permissions to make this change.

Setting the default as `STANDARD_CONTROL` to fix.

Plan has been run against several accounts, all showing "No changes."