### PR TITLE
AWS Provider 5.0 upgrade

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -101,7 +101,7 @@ resource "aws_iam_role_policy_attachment" "config-publish-policy" {
 
 # AWS Config: configure an S3 bucket
 module "config-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v6.4.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"
   providers = {
     aws.bucket-replication = aws.replication-region
   }

--- a/modules/access-analyzer/versions.tf
+++ b/modules/access-analyzer/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.20.0"
+      version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0.1"
 }

--- a/modules/backup/versions.tf
+++ b/modules/backup/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.20.0"
+      version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0.1"
 }

--- a/modules/cloudtrail/versions.tf
+++ b/modules/cloudtrail/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 3.47.0"
+      version               = "~> 5.0"
       configuration_aliases = [aws.replication-region]
     }
   }

--- a/modules/config/versions.tf
+++ b/modules/config/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.20.0"
+      version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0.1"
 }

--- a/modules/ebs/versions.tf
+++ b/modules/ebs/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.20.0"
+      version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0.1"
 }

--- a/modules/guardduty/versions.tf
+++ b/modules/guardduty/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.20.0"
+      version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0.1"
 }

--- a/modules/iam/versions.tf
+++ b/modules/iam/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.20.0"
+      version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0.1"
 }

--- a/modules/securityhub-alarms/versions.tf
+++ b/modules/securityhub-alarms/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.20.0"
+      version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0.1"
 }

--- a/modules/securityhub/versions.tf
+++ b/modules/securityhub/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.20.0"
+      version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0.1"
 }

--- a/modules/support/versions.tf
+++ b/modules/support/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.20.0"
+      version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0.1"
 }

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.20.0"
+      version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.0.1"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 5.0.0"
+      version = "~> 5.0"
       configuration_aliases = [
         aws.replication-region,
         aws.ap-northeast-1,


### PR DESCRIPTION
Bumps version constraint to `~> 5.0`.
Related to https://github.com/ministryofjustice/modernisation-platform/issues/4173
Will require a further PR referring to an updated version of the `modernisation-platform-terraform-s3-bucket` module once that has been updated to set `~> 5.0` as its version.