### PR TITLE
Move enabling security hub to organizations

### DIFF
--- a/modules/securityhub/README.md
+++ b/modules/securityhub/README.md
@@ -1,9 +1,9 @@
 # AWS SecurityHub
 
-Terraform module for enabling [AWS SecurityHub](https://aws.amazon.com/security-hub/).
+Terraform module for enabling [AWS SecurityHub](https://aws.amazon.com/security-hub/) standards.  The enabling of Security Hub is done at the Organizations level.
 
 ## SecurityHub Standards and remediation
-This module enables the following SecurityHub standards, and this repository holds other modules to remediate some failed findings:
+This module enables or brings in to Terraform the following SecurityHub standards, and this repository holds other modules to remediate some failed findings:
 - [x] [AWS Foundational Security Best Practices v1.0.0](AWS.md)
 - [x] [CIS AWS Foundations Benchmark v1.2.0](CIS.md)
 - [x] [PCI DSS v3.2.1](PCI.md)

--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -2,26 +2,21 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 # Enable SecurityHub
-resource "aws_securityhub_account" "default" {
-  control_finding_generator = "STANDARD_CONTROL"
-}
+# Now enabled via organizations
 
 # Enable Standard: AWS Foundational Security Best Practices
 resource "aws_securityhub_standards_subscription" "aws-foundational" {
   standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-foundational-security-best-practices/v/1.0.0"
-  depends_on    = [aws_securityhub_account.default]
 }
 
 # Enable Standard: CIS AWS Foundations
 resource "aws_securityhub_standards_subscription" "cis" {
   standards_arn = "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
-  depends_on    = [aws_securityhub_account.default]
 }
 
 # Enable Standard: PCI DSS v3.2.1
 resource "aws_securityhub_standards_subscription" "pci" {
   standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/pci-dss/v/3.2.1"
-  depends_on    = [aws_securityhub_account.default]
 }
 
 # Disabled standard controls - controls that we are not using as we have other mitigating factors in place


### PR DESCRIPTION
This moves the enabling of security hub to the organisation level, all new accounts will be added to security hub automatically.  See PR here - https://github.com/ministryofjustice/aws-root-account/pull/769

Final steps after this are to remove the security hub resource from state.  A script has been prepared and tested against sprinkler development.