### PR TITLE
Allow customers to exclude EC2 instances from backups

### DIFF
--- a/modules/backup/README.md
+++ b/modules/backup/README.md
@@ -6,12 +6,18 @@ Terraform module for configuring [AWS Backup](https://aws.amazon.com/backup/).
 This module creates a new vault, named `everything`, in which the backup plans use as a destination.
 
 ## Backup Plans
-This module creates backup plans:
-- `backup-daily-retain-30-days` plans daily backups, which are deleted every 30 days. The backups start from 00:30am and must finish within 6 hours of starting.
+This module creates two backup plans:
+- `backup-daily-retain-30-days` plans daily backups, which are deleted every 30 days. The backups start at 0:30 and must finish within 6 hours of starting.
+- `backup-daily-cold-storage-monthly-retain-30-days` plans daily backups, which are deleted every 30 days. As above, the backups start at 0:30 and must finish within 6 hours of starting.
 
 ## Backup Selections
-This module selects resources with the following tag key values to backup using the above plan, automatically:
+This module selects resources with the following tag/key values to backup using the above plan. Resources can be exluded by setting `skip-backup` to `true`.
 - `is-production`: `true`
+- `skip-backup`: `!true`
+
+Non-production environments can also make use of backup plans with the following tag/key values:
+- `backup`: `true`
+- `is-production`: `!true`
 
 ## Usage
 

--- a/modules/backup/README.md
+++ b/modules/backup/README.md
@@ -11,13 +11,13 @@ This module creates two backup plans:
 - `backup-daily-cold-storage-monthly-retain-30-days` plans daily backups, which are deleted every 30 days. As above, the backups start at 0:30 and must finish within 6 hours of starting.
 
 ## Backup Selections
-This module selects resources with the following tag/key values to backup using the above plan. Resources can be exluded by setting `skip-backup` to `true`.
+This module selects resources for the default plan with the following tag/key values. Resources can be excluded by setting `backup` to `false`:
 - `is-production`: `true`
-- `skip-backup`: `!true`
+- `backup`: `!false`
 
 Non-production environments can also make use of backup plans with the following tag/key values:
-- `backup`: `true`
 - `is-production`: `!true`
+- `backup`: `true`
 
 ## Usage
 

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -51,10 +51,15 @@ resource "aws_backup_selection" "production" {
   iam_role_arn = var.iam_role_arn
   plan_id      = aws_backup_plan.default.id
 
-  selection_tag {
-    type  = "STRINGEQUALS"
-    key   = "is-production"
-    value = "true"
+  condition {
+    string_equals {
+      key   = "aws:ResourceTag/is-production"
+      value = "true"
+    }
+    string_not_equals {
+      key   = "aws:ResourceTag/skip_backup"
+      value = "true"
+    }
   }
 }
 

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -102,12 +102,12 @@ resource "aws_backup_selection" "non_production" {
   resources    = ["*"]
 
   condition {
-    string_equals {
-      key   = "aws:ResourceTag/backup"
-      value = "true"
-    }
     string_not_equals {
       key   = "aws:ResourceTag/is-production"
+      value = "true"
+    }
+    string_equals {
+      key   = "aws:ResourceTag/backup"
       value = "true"
     }
   }

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -57,8 +57,8 @@ resource "aws_backup_selection" "production" {
       value = "true"
     }
     string_not_equals {
-      key   = "aws:ResourceTag/skip_backup"
-      value = "true"
+      key   = "aws:ResourceTag/backup"
+      value = "false"
     }
   }
 }


### PR DESCRIPTION
This PR resolves https://github.com/ministryofjustice/modernisation-platform/issues/4802

This PR refactors the selection conditions for the `default` backup plan. It continues to select based on the `is-production/true` tag/key value, but adds `backup/!false` which will mean that customers can set `backup/false` to exclude production hosts from the backup plan.

For non-production backups, these are still selected based on `is-production/!true` and `backup/true` ensuring that only non-production resources with `backup/true` are included in the `non-production` backup plan.