### PR TITLE
add missing resources statement to aws_backup_selection

### DIFF
--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -50,6 +50,7 @@ resource "aws_backup_selection" "production" {
   name         = "is-production-true"
   iam_role_arn = var.iam_role_arn
   plan_id      = aws_backup_plan.default.id
+  resources    = ["*"]
 
   condition {
     string_equals {


### PR DESCRIPTION
Without `resources    = ["*"]` in the `aws_backup_selection` resource, the resource creation fails with an error like so:
```
  Message_: "Invalid backup selection. Either 'ListOfTags' or 'Resources' section must be non-empty."
```