### PR TITLE
issue/5012.

### DIFF
--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -9,3 +9,9 @@ resource "aws_iam_account_password_policy" "default" {
   require_symbols                = true
   require_uppercase_characters   = true
 }
+
+
+# Prevent making AMIs publicly accessible in the account.
+resource "aws_ec2_image_block_public_access" "block-public-ami" {
+  state = "block-new-sharing"
+}


### PR DESCRIPTION
Adds a "aws_ec2_image_block_public_access" resource to the module to prevent any new AMIs created in member accounts from being publicly shared.

Ref: https://github.com/ministryofjustice/modernisation-platform/issues/5012 for further information.