### PR TITLE
Add S3 backup policy to AWSBackup role

### DIFF
--- a/backup.tf
+++ b/backup.tf
@@ -24,6 +24,11 @@ resource "aws_iam_role_policy_attachment" "backup" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
 }
 
+resource "aws_iam_role_policy_attachment" "backupS3" {
+  role       = aws_iam_role.backup.id
+  policy_arn = "arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup"
+}
+
 module "backup-ap-northeast-1" {
   for_each = contains(var.enabled_backup_regions, "ap-northeast-1") ? local.enabled : local.not_enabled
 


### PR DESCRIPTION
This PR attaches the 'AWSBackupServiceRolePolicyForS3Backup' policy to the AWSBackup IAM role which should resolve the access denied errors reported in bug https://github.com/ministryofjustice/modernisation-platform/issues/6152