### PR TITLE
Alerting created

### DIFF
--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -129,6 +129,6 @@ resource "aws_sns_topic_subscription" "email_subscription" {
 # Attach the SNS topic to the backup vault for notifications
 resource "aws_backup_vault_notifications" "example" {
   backup_vault_events = ["BACKUP_JOB_FAILED"]
-  backup_vault_name = aws_backup_vault.default.name
-  sns_topic_arn     = aws_sns_topic.backup_failure_topic.arn
+  backup_vault_name   = aws_backup_vault.default.name
+  sns_topic_arn       = aws_sns_topic.backup_failure_topic.arn
 }

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -118,10 +118,7 @@ resource "aws_backup_selection" "non_production" {
 resource "aws_sns_topic" "backup_failure_topic" {
   kms_master_key_id = "alias/aws/sns"
   name              = "backup_failure_topic"
-  tags = {
-    Name        = "Backup failure topic"
-    Description = "This backup topic is so the Modernisation Platform team can subscribe to backup notifications from selected accounts, or teams using member-unrestricted accounts can create their own subscriptions."
-  }
+  tags = var.tags
 }
 
 # Attaches the SNS topic to the backup vault to subscribe for notifications

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -118,6 +118,10 @@ resource "aws_backup_selection" "non_production" {
 resource "aws_sns_topic" "backup_failure_topic" {
   kms_master_key_id = "alias/aws/sns"
   name = "backup_failure_topic"
+  tags = {
+    Name        = "Backup failure topic"
+    Description = "This backup topic is so the Modernisation Platform team can subscribe to backup notifications from selected accounts, or teams using member-unrestricted accounts can create their own subscriptions."
+  }
 }
 
 # Attaches the SNS topic to the backup vault to subscribe for notifications

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -116,6 +116,7 @@ resource "aws_backup_selection" "non_production" {
 
 # SNS topic
 resource "aws_sns_topic" "backup_failure_topic" {
+  kms_master_key_id = "alias/aws/sns"
   name = "backup_failure_topic"
 }
 

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -124,6 +124,7 @@ resource "aws_sns_topic" "backup_failure_topic" {
   })
 }
 
+
 # Attaches the SNS topic to the backup vault to subscribe for notifications
 resource "aws_backup_vault_notifications" "aws_backup_vault_notifications" {
   backup_vault_events = ["BACKUP_JOB_FAILED"]

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -113,3 +113,22 @@ resource "aws_backup_selection" "non_production" {
     }
   }
 }
+
+# SNS topic
+resource "aws_sns_topic" "backup_failure_topic" {
+  name = "backup_failure_topic"
+}
+
+# SNS subscription
+resource "aws_sns_topic_subscription" "email_subscription" {
+  topic_arn = aws_sns_topic.backup_failure_topic.arn
+  protocol  = "email"
+  endpoint  = "edward.proctor@digital.justice.gov.uk"
+}
+
+# Attach the SNS topic to the backup vault for notifications
+resource "aws_backup_vault_notifications" "example" {
+  backup_vault_events = ["BACKUP_JOB_FAILED"]
+  backup_vault_name = aws_backup_vault.default.name
+  sns_topic_arn     = aws_sns_topic.backup_failure_topic.arn
+}

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -117,7 +117,7 @@ resource "aws_backup_selection" "non_production" {
 # SNS topic
 resource "aws_sns_topic" "backup_failure_topic" {
   kms_master_key_id = "alias/aws/sns"
-  name = "backup_failure_topic"
+  name              = "backup_failure_topic"
   tags = {
     Name        = "Backup failure topic"
     Description = "This backup topic is so the Modernisation Platform team can subscribe to backup notifications from selected accounts, or teams using member-unrestricted accounts can create their own subscriptions."

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -120,7 +120,7 @@ resource "aws_sns_topic" "backup_failure_topic" {
 }
 
 # Attaches the SNS topic to the backup vault to subscribe for notifications
-resource "aws_backup_vault_notifications" "example" {
+resource "aws_backup_vault_notifications" "aws_backup_vault_notifications" {
   backup_vault_events = ["BACKUP_JOB_FAILED"]
   backup_vault_name   = aws_backup_vault.default.name
   sns_topic_arn       = aws_sns_topic.backup_failure_topic.arn

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -118,7 +118,10 @@ resource "aws_backup_selection" "non_production" {
 resource "aws_sns_topic" "backup_failure_topic" {
   kms_master_key_id = "alias/aws/sns"
   name              = "backup_failure_topic"
-  tags = var.tags
+  tags = merge(var.tags, {
+  { Name        = "Backup failure topic"},
+  { Description = "This backup topic is so the Modernisation Platform team can subscribe to backup notifications from selected accounts, or teams using member-unrestricted accounts can create their own subscriptions." }
+  })
 }
 
 # Attaches the SNS topic to the backup vault to subscribe for notifications

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -119,7 +119,7 @@ resource "aws_sns_topic" "backup_failure_topic" {
   kms_master_key_id = "alias/aws/sns"
   name              = "backup_failure_topic"
   tags = merge(var.tags, {
-  Description = "This backup topic is so the MP team can subscribe to backup notifications from selected accounts and teams using member-unrestricted accounts can create their own subscriptions" 
+    Description = "This backup topic is so the MP team can subscribe to backup notifications from selected accounts and teams using member-unrestricted accounts can create their own subscriptions"
   })
 }
 

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -119,14 +119,7 @@ resource "aws_sns_topic" "backup_failure_topic" {
   name = "backup_failure_topic"
 }
 
-# SNS subscription
-resource "aws_sns_topic_subscription" "email_subscription" {
-  topic_arn = aws_sns_topic.backup_failure_topic.arn
-  protocol  = "email"
-  endpoint  = "edward.proctor@digital.justice.gov.uk"
-}
-
-# Attach the SNS topic to the backup vault for notifications
+# Attaches the SNS topic to the backup vault to subscribe for notifications
 resource "aws_backup_vault_notifications" "example" {
   backup_vault_events = ["BACKUP_JOB_FAILED"]
   backup_vault_name   = aws_backup_vault.default.name

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -118,11 +118,8 @@ resource "aws_backup_selection" "non_production" {
 resource "aws_sns_topic" "backup_failure_topic" {
   kms_master_key_id = "alias/aws/sns"
   name              = "backup_failure_topic"
-
   tags = merge(var.tags, {
-  Name        = "Backup failure topic"
-  Description = "This backup topic is so the Modernisation Platform team can subscribe to backup notifications from selected accounts, or teams using member-unrestricted accounts can create their own subscriptions." 
-
+  Description = "This backup topic is so the MP team can subscribe to backup notifications from selected accounts and teams using member-unrestricted accounts can create their own subscriptions" 
   })
 }
 


### PR DESCRIPTION
This creates sns topics and notifications on all areas that use the baseline module (currently in bootstrap, so all accounts)

No subscriptions though. This will be done outside the module, where we can control which accounts we want notifications from.

For more information, I grabbed this from a slack discussion

```

Creating the topic in the module and and aws_backup_vault_notifications will do.. well nothing as the subscription is not in this code. What it will do is create it in every account.

The subscription, logic etc is being done in another PR and will be applied to all accounts apart from member-unrestricted
This way, if any member-unrestricted fancy monitoring the backups and utilising them, they can, but we wont, however it gives them stuff to tie into

Other PR is located here -  https://moj.enterprise.slack.com/archives/C013RM6MFFW/p1708618646636819
```
