### PR TITLE
Allow customer managed KMS key for backup SNS topic

### DIFF
--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -115,8 +115,9 @@ resource "aws_backup_selection" "non_production" {
 }
 
 # SNS topic
+#trivy:ignore:avd-aws-0136
 resource "aws_sns_topic" "backup_failure_topic" {
-  kms_master_key_id = "alias/aws/sns"
+  kms_master_key_id = var.sns_backup_topic_key
   name              = "backup_failure_topic"
   tags = merge(var.tags, {
     Description = "This backup topic is so the MP team can subscribe to backup notifications from selected accounts and teams using member-unrestricted accounts can create their own subscriptions"

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -4,8 +4,8 @@ variable "iam_role_arn" {
 }
 
 variable "sns_backup_topic_key" {
-  type = string
-  default = "alias/aws/sns"
+  type        = string
+  default     = "alias/aws/sns"
   description = "KMS key used to encrypt backup failure SNS topic"
 }
 

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -3,6 +3,12 @@ variable "iam_role_arn" {
   description = "IAM role ARN for the AWS Backup service role"
 }
 
+variable "sns_backup_topic_key" {
+  type = string
+  default = "alias/aws/sns"
+  description = "KMS key used to encrypt backup failure SNS topic"
+}
+
 variable "tags" {
   default     = {}
   description = "Tags to apply to resources, where applicable"


### PR DESCRIPTION
Addresses `trivy` findings in https://github.com/ministryofjustice/modernisation-platform/actions/runs/8044933763/job/21969343240