### PR TITLE
Add pass-through variable for cloudtrail s3 management events selector

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,9 @@ module "cloudtrail" {
   providers = {
     aws.replication-region = aws.replication-region
   }
-  cloudtrail_kms_key = var.cloudtrail_kms_key
-  cloudtrail_bucket  = local.cloudtrail_bucket
+  cloudtrail_kms_key               = var.cloudtrail_kms_key
+  cloudtrail_bucket                = local.cloudtrail_bucket
+  enable_cloudtrail_s3_mgmt_events = var.enable_cloudtrail_s3_mgmt_events
   # replication_role_arn = module.s3-replication-role.role.arn
   tags = var.tags
 }

--- a/modules/cloudtrail/variables.tf
+++ b/modules/cloudtrail/variables.tf
@@ -12,10 +12,11 @@ variable "cloudtrail_bucket" {
   description = "Name of centralised Cloudtrail bucket"
   type        = string
 }
-variable "tags" {
-  default     = {}
-  description = "Tags to apply to resources, where applicable"
-  type        = map(any)
+
+variable "enable_cloudtrail_s3_mgmt_events" {
+  type        = bool
+  default     = true
+  description = "Enable CT Object-level logging, defaults to true"
 }
 
 variable "retention_days" {
@@ -24,8 +25,8 @@ variable "retention_days" {
   type        = number
 }
 
-variable "enable_cloudtrail_s3_mgmt_events" {
-  type        = bool
-  default     = true
-  description = "Enable CT Object-level logging, defaults to true"
+variable "tags" {
+  default     = {}
+  description = "Tags to apply to resources, where applicable"
+  type        = map(any)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,12 @@
-variable "root_account_id" {
+variable "cloudtrail_kms_key" {
+  description = "Arn of kms key used for cloudtrail logs"
   type        = string
-  description = "The AWS Organisations root account ID that this account should be part of"
 }
 
-variable "tags" {
-  default     = {}
-  description = "Tags to apply to resources, where applicable"
-  type        = map(any)
+variable "enable_cloudtrail_s3_mgmt_events" {
+  type        = bool
+  default     = true
+  description = "Enable CT Object-level logging, defaults to true"
 }
 
 variable "enabled_access_analyzer_regions" {
@@ -51,7 +51,13 @@ variable "enabled_vpc_regions" {
   type        = list(string)
 }
 
-variable "cloudtrail_kms_key" {
-  description = "Arn of kms key used for cloudtrail logs"
+variable "root_account_id" {
   type        = string
+  description = "The AWS Organisations root account ID that this account should be part of"
+}
+
+variable "tags" {
+  default     = {}
+  description = "Tags to apply to resources, where applicable"
+  type        = map(any)
 }


### PR DESCRIPTION
In response to [this Slack request](https://mojdt.slack.com/archives/C01A7QK5VM1/p1711528538461979) I noted that there was no way to optionally pass through a variable for cloudtrail S3 management events when the module is remotely called.

This PR introduces `var.enable_cloudtrail_s3_mgmt_events` to the root of this module, so that it can be passed in and used in the `modules/cloudtrail` module inside this module. Essentially this will happen:

```
module "baselines" {
  source = this-repository
  enable_cloudtrail_s3_mgmt_events = true
}

# this variable will be read in main.tf in the cached version of the module like so:
module "cloudtrail" {
  source = "./modules/cloudtrail"
  enable_cloudtrail_s3_mgmt_events = var.enable_cloudtrail_s3_mgmt_events (in this case, true)
}

# finally the selector will be received by the dynamic block in the cloudtrail module:
resource "aws_cloudtrail" "cloudtrail" {
  dynamic "event_selector" {
    for_each = var.enable_cloudtrail_s3_mgmt_events ? [1] : []
  }
}
```
