### PR TITLE
Changes to metrix to prevent nosy alarms

### DIFF
--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -92,9 +92,9 @@ resource "aws_cloudwatch_metric_alarm" "unauthorised-api-calls" {
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.unauthorised-api-calls.id
   namespace           = "LogMetrics"
-  period              = "300"
+  period              = "60"
   statistic           = "Sum"
-  threshold           = "1"
+  threshold           = "5"
   treat_missing_data  = "notBreaching"
 
   tags = var.tags
@@ -243,9 +243,9 @@ resource "aws_cloudwatch_metric_alarm" "sign-in-failures" {
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.sign-in-failures.id
   namespace           = "LogMetrics"
-  period              = "300"
+  period              = "60"
   statistic           = "Sum"
-  threshold           = "1"
+  threshold           = "5"
   treat_missing_data  = "notBreaching"
 
   tags = var.tags
@@ -363,9 +363,9 @@ resource "aws_cloudwatch_metric_alarm" "security-group-changes" {
   evaluation_periods  = "1"
   metric_name         = aws_cloudwatch_log_metric_filter.security-group-changes.id
   namespace           = "LogMetrics"
-  period              = "300"
+  period              = "120"
   statistic           = "Sum"
-  threshold           = "1"
+  threshold           = "5"
   treat_missing_data  = "notBreaching"
 
   tags = var.tags


### PR DESCRIPTION
We currently have security hub alerts which go off on pager duty. We need to look at these alerts and either resolve the underlying issue, or silence them and add a more reasonable alert.

For example security hub requires any failed login attempts to raise an alert. This happens occasionally and we don't need to know about this. We have to keep the original alert for security hub compliance, but we could mute that alert on pager duty and create a more useful one, such as 5 failed login attempts in a 1min period.

This PR changes three of the matrix which will suppress these alarms