### PR TITLE
Fix KMS key data call with its own key.

### DIFF
--- a/backup.tf
+++ b/backup.tf
@@ -31,7 +31,6 @@ resource "aws_iam_role_policy_attachment" "backupS3" {
 
 module "backup-ap-northeast-1" {
   for_each = contains(var.enabled_backup_regions, "ap-northeast-1") ? local.enabled : local.not_enabled
-  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.ap-northeast-1
@@ -42,7 +41,6 @@ module "backup-ap-northeast-1" {
 
 module "backup-ap-northeast-2" {
   for_each = contains(var.enabled_backup_regions, "ap-northeast-2") ? local.enabled : local.not_enabled
-  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.ap-northeast-2
@@ -53,7 +51,7 @@ module "backup-ap-northeast-2" {
 
 module "backup-ap-south-1" {
   for_each = contains(var.enabled_backup_regions, "ap-south-1") ? local.enabled : local.not_enabled
-  depends_on = [module.securityhub-alarms]
+
   source = "./modules/backup"
   providers = {
     aws = aws.ap-south-1
@@ -64,7 +62,7 @@ module "backup-ap-south-1" {
 
 module "backup-ap-southeast-1" {
   for_each = contains(var.enabled_backup_regions, "ap-southeast-1") ? local.enabled : local.not_enabled
-  depends_on = [module.securityhub-alarms]
+
   source = "./modules/backup"
   providers = {
     aws = aws.ap-southeast-1
@@ -75,7 +73,7 @@ module "backup-ap-southeast-1" {
 
 module "backup-ap-southeast-2" {
   for_each = contains(var.enabled_backup_regions, "ap-southeast-2") ? local.enabled : local.not_enabled
-  depends_on = [module.securityhub-alarms]
+
   source = "./modules/backup"
   providers = {
     aws = aws.ap-southeast-2
@@ -86,7 +84,7 @@ module "backup-ap-southeast-2" {
 
 module "backup-ca-central-1" {
   for_each = contains(var.enabled_backup_regions, "ca-central-1") ? local.enabled : local.not_enabled
-  depends_on = [module.securityhub-alarms]
+
   source = "./modules/backup"
   providers = {
     aws = aws.ca-central-1
@@ -97,7 +95,7 @@ module "backup-ca-central-1" {
 
 module "backup-eu-central-1" {
   for_each = contains(var.enabled_backup_regions, "eu-central-1") ? local.enabled : local.not_enabled
-  depends_on = [module.securityhub-alarms]
+
   source = "./modules/backup"
   providers = {
     aws = aws.eu-central-1
@@ -108,7 +106,7 @@ module "backup-eu-central-1" {
 
 module "backup-eu-north-1" {
   for_each = contains(var.enabled_backup_regions, "eu-north-1") ? local.enabled : local.not_enabled
-  depends_on = [module.securityhub-alarms]
+
   source = "./modules/backup"
   providers = {
     aws = aws.eu-north-1
@@ -119,7 +117,7 @@ module "backup-eu-north-1" {
 
 module "backup-eu-west-1" {
   for_each = contains(var.enabled_backup_regions, "eu-west-1") ? local.enabled : local.not_enabled
-  depends_on = [module.securityhub-alarms]
+
   source = "./modules/backup"
   providers = {
     aws = aws.eu-west-1
@@ -130,7 +128,7 @@ module "backup-eu-west-1" {
 
 module "backup-eu-west-2" {
   for_each = contains(var.enabled_backup_regions, "eu-west-2") ? local.enabled : local.not_enabled
-  depends_on = [module.securityhub-alarms]
+  
   source = "./modules/backup"
   providers = {
     aws = aws.eu-west-2
@@ -141,7 +139,7 @@ module "backup-eu-west-2" {
 
 module "backup-eu-west-3" {
   for_each = contains(var.enabled_backup_regions, "eu-west-3") ? local.enabled : local.not_enabled
-  depends_on = [module.securityhub-alarms]
+
   source = "./modules/backup"
   providers = {
     aws = aws.eu-west-3
@@ -152,7 +150,7 @@ module "backup-eu-west-3" {
 
 module "backup-sa-east-1" {
   for_each = contains(var.enabled_backup_regions, "sa-east-1") ? local.enabled : local.not_enabled
-  depends_on = [module.securityhub-alarms]
+
   source = "./modules/backup"
   providers = {
     aws = aws.sa-east-1
@@ -163,7 +161,7 @@ module "backup-sa-east-1" {
 
 module "backup-us-east-1" {
   for_each = contains(var.enabled_backup_regions, "us-east-1") ? local.enabled : local.not_enabled
-  depends_on = [module.securityhub-alarms]
+
   source = "./modules/backup"
   providers = {
     aws = aws.us-east-1
@@ -174,7 +172,7 @@ module "backup-us-east-1" {
 
 module "backup-us-east-2" {
   for_each = contains(var.enabled_backup_regions, "us-east-2") ? local.enabled : local.not_enabled
-  depends_on = [module.securityhub-alarms]
+
   source = "./modules/backup"
   providers = {
     aws = aws.us-east-2
@@ -185,7 +183,7 @@ module "backup-us-east-2" {
 
 module "backup-us-west-1" {
   for_each = contains(var.enabled_backup_regions, "us-west-1") ? local.enabled : local.not_enabled
-  depends_on = [module.securityhub-alarms]
+
   source = "./modules/backup"
   providers = {
     aws = aws.us-west-1
@@ -196,7 +194,7 @@ module "backup-us-west-1" {
 
 module "backup-us-west-2" {
   for_each = contains(var.enabled_backup_regions, "us-west-2") ? local.enabled : local.not_enabled
-  depends_on = [module.securityhub-alarms]
+
   source = "./modules/backup"
   providers = {
     aws = aws.us-west-2

--- a/backup.tf
+++ b/backup.tf
@@ -31,7 +31,7 @@ resource "aws_iam_role_policy_attachment" "backupS3" {
 
 module "backup-ap-northeast-1" {
   for_each = contains(var.enabled_backup_regions, "ap-northeast-1") ? local.enabled : local.not_enabled
-  source = "./modules/backup"
+  source   = "./modules/backup"
   providers = {
     aws = aws.ap-northeast-1
   }
@@ -41,7 +41,7 @@ module "backup-ap-northeast-1" {
 
 module "backup-ap-northeast-2" {
   for_each = contains(var.enabled_backup_regions, "ap-northeast-2") ? local.enabled : local.not_enabled
-  source = "./modules/backup"
+  source   = "./modules/backup"
   providers = {
     aws = aws.ap-northeast-2
   }
@@ -128,7 +128,7 @@ module "backup-eu-west-1" {
 
 module "backup-eu-west-2" {
   for_each = contains(var.enabled_backup_regions, "eu-west-2") ? local.enabled : local.not_enabled
-  
+
   source = "./modules/backup"
   providers = {
     aws = aws.eu-west-2

--- a/backup.tf
+++ b/backup.tf
@@ -31,7 +31,7 @@ resource "aws_iam_role_policy_attachment" "backupS3" {
 
 module "backup-ap-northeast-1" {
   for_each = contains(var.enabled_backup_regions, "ap-northeast-1") ? local.enabled : local.not_enabled
-
+  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.ap-northeast-1
@@ -42,7 +42,7 @@ module "backup-ap-northeast-1" {
 
 module "backup-ap-northeast-2" {
   for_each = contains(var.enabled_backup_regions, "ap-northeast-2") ? local.enabled : local.not_enabled
-
+  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.ap-northeast-2
@@ -53,7 +53,7 @@ module "backup-ap-northeast-2" {
 
 module "backup-ap-south-1" {
   for_each = contains(var.enabled_backup_regions, "ap-south-1") ? local.enabled : local.not_enabled
-
+  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.ap-south-1
@@ -64,7 +64,7 @@ module "backup-ap-south-1" {
 
 module "backup-ap-southeast-1" {
   for_each = contains(var.enabled_backup_regions, "ap-southeast-1") ? local.enabled : local.not_enabled
-
+  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.ap-southeast-1
@@ -75,7 +75,7 @@ module "backup-ap-southeast-1" {
 
 module "backup-ap-southeast-2" {
   for_each = contains(var.enabled_backup_regions, "ap-southeast-2") ? local.enabled : local.not_enabled
-
+  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.ap-southeast-2
@@ -86,7 +86,7 @@ module "backup-ap-southeast-2" {
 
 module "backup-ca-central-1" {
   for_each = contains(var.enabled_backup_regions, "ca-central-1") ? local.enabled : local.not_enabled
-
+  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.ca-central-1
@@ -97,7 +97,7 @@ module "backup-ca-central-1" {
 
 module "backup-eu-central-1" {
   for_each = contains(var.enabled_backup_regions, "eu-central-1") ? local.enabled : local.not_enabled
-
+  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.eu-central-1
@@ -108,7 +108,7 @@ module "backup-eu-central-1" {
 
 module "backup-eu-north-1" {
   for_each = contains(var.enabled_backup_regions, "eu-north-1") ? local.enabled : local.not_enabled
-
+  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.eu-north-1
@@ -119,7 +119,7 @@ module "backup-eu-north-1" {
 
 module "backup-eu-west-1" {
   for_each = contains(var.enabled_backup_regions, "eu-west-1") ? local.enabled : local.not_enabled
-
+  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.eu-west-1
@@ -130,7 +130,7 @@ module "backup-eu-west-1" {
 
 module "backup-eu-west-2" {
   for_each = contains(var.enabled_backup_regions, "eu-west-2") ? local.enabled : local.not_enabled
-
+  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.eu-west-2
@@ -141,7 +141,7 @@ module "backup-eu-west-2" {
 
 module "backup-eu-west-3" {
   for_each = contains(var.enabled_backup_regions, "eu-west-3") ? local.enabled : local.not_enabled
-
+  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.eu-west-3
@@ -152,7 +152,7 @@ module "backup-eu-west-3" {
 
 module "backup-sa-east-1" {
   for_each = contains(var.enabled_backup_regions, "sa-east-1") ? local.enabled : local.not_enabled
-
+  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.sa-east-1
@@ -163,7 +163,7 @@ module "backup-sa-east-1" {
 
 module "backup-us-east-1" {
   for_each = contains(var.enabled_backup_regions, "us-east-1") ? local.enabled : local.not_enabled
-
+  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.us-east-1
@@ -174,7 +174,7 @@ module "backup-us-east-1" {
 
 module "backup-us-east-2" {
   for_each = contains(var.enabled_backup_regions, "us-east-2") ? local.enabled : local.not_enabled
-
+  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.us-east-2
@@ -185,7 +185,7 @@ module "backup-us-east-2" {
 
 module "backup-us-west-1" {
   for_each = contains(var.enabled_backup_regions, "us-west-1") ? local.enabled : local.not_enabled
-
+  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.us-west-1
@@ -196,7 +196,7 @@ module "backup-us-west-1" {
 
 module "backup-us-west-2" {
   for_each = contains(var.enabled_backup_regions, "us-west-2") ? local.enabled : local.not_enabled
-
+  depends_on = [module.securityhub-alarms]
   source = "./modules/backup"
   providers = {
     aws = aws.us-west-2

--- a/main.tf
+++ b/main.tf
@@ -30,10 +30,5 @@ module "securityhub-alarms" {
   tags = var.tags
 }
 
-# module "s3-replication-role" {
-#   source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role?ref=v1.0.0"
-#   buckets = [
-#     module.config-bucket.bucket.arn
-#   ]
-#   tags = var.tags
-# }
+
+

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -1,23 +1,66 @@
 locals {
   cold_storage_after = 30
   is_production      = can(regex("production|default", terraform.workspace))
-  kms_master_key_id  = (data.aws_region.current.name == "eu-west-2" && length(data.aws_kms_alias.securityhub-alarms) > 0) ? data.aws_kms_alias.securityhub-alarms[0].target_key_id : ""
 }
+
+data "aws_caller_identity" "current" {}
 
 # Fetch the current AWS region
 data "aws_region" "current" {}
 
-# Define the KMS alias, conditionally fetched if the region is eu-west-2
-data "aws_kms_alias" "securityhub-alarms" {
-  count             = data.aws_region.current.name == "eu-west-2" ? 1 : 0
-  name  = "alias/securityhub-alarms-key-multi-region"
+# Backup alarms KMS multi-Region
+resource "aws_kms_key" "backup_alarms_multi_region" {
+  deletion_window_in_days = 7
+  description             = "Backup alarms encryption key"
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.backup-alarms-kms.json
+  tags                    = var.tags
+  multi_region            = true
 }
+
+resource "aws_kms_alias" "backup_alarms_multi_region" {
+  name          = "alias/backup-alarms-key-multi-region"
+  target_key_id = aws_kms_key.backup_alarms_multi_region.id
+}
+
+data "aws_iam_policy_document" "backup-alarms-kms" {
+
+  #checkov:skip=CKV_AWS_356: ""
+  #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
+  #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints - This is applied to a specific SNS topic"
+
+  statement {
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudwatch.amazonaws.com"]
+    }
+  }
+}
+
 
 # Define the SNS topic, conditionally created if the region is eu-west-2 and is production
 resource "aws_sns_topic" "backup_vault_topic" {
   #checkov:skip=CKV_AWS_26:"topic is encrypted, but doesn't like the local reference"  
   count             = (local.is_production && data.aws_region.current.name == "eu-west-2") ? 1 : 0
-  kms_master_key_id = local.kms_master_key_id
+  kms_master_key_id = aws_kms_key.backup_alarms_multi_region.id
   name              = var.backup_vault_lock_sns_topic_name
   tags = merge(var.tags, {
     Description = "This backup topic is so the MP team can subscribe to backup vault lock being turned off and member accounts can create their own subscriptions"
@@ -148,7 +191,7 @@ resource "aws_backup_selection" "non_production" {
 resource "aws_sns_topic" "backup_failure_topic" {
   count = (local.is_production && data.aws_region.current.name == "eu-west-2") ? 1 : 0
   #checkov:skip=CKV_AWS_26:"topic is encrypted, but doesn't like the local reference"
-  kms_master_key_id = local.kms_master_key_id
+  kms_master_key_id = aws_kms_key.backup_alarms_multi_region.id
   name              = var.backup_aws_sns_topic_name
   tags = merge(var.tags, {
     Description = "This backup topic is so the MP team can subscribe to backup notifications from selected accounts and teams using member-unrestricted accounts can create their own subscriptions"

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -9,7 +9,7 @@ data "aws_region" "current" {}
 
 # Define the KMS alias, conditionally fetched if the region is eu-west-2
 data "aws_kms_alias" "securityhub-alarms" {
-  count = data.aws_region.current.name == "eu-west-2" ? 1 : 0
+  count             = data.aws_region.current.name == "eu-west-2" ? 1 : 0
   name  = "alias/securityhub-alarms-key-multi-region"
 }
 
@@ -23,7 +23,6 @@ resource "aws_sns_topic" "backup_vault_topic" {
     Description = "This backup topic is so the MP team can subscribe to backup vault lock being turned off and member accounts can create their own subscriptions"
   })
 }
-
 
 resource "aws_backup_vault" "default" {
   #checkov:skip=CKV_AWS_166: "Ensure Backup Vault is encrypted at rest using KMS CMK - Tricky to implement, hence using AWS managed KMS key"

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -1,7 +1,5 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_region" "current" {}
-
 # AWS CloudWatch doesn't support using the AWS-managed KMS key for publishing things from CloudWatch to SNS
 # See: https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-receive-sns-for-alarm-trigger/
 resource "aws_kms_key" "securityhub-alarms" {

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -1,5 +1,7 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_region" "current" {}
+
 # AWS CloudWatch doesn't support using the AWS-managed KMS key for publishing things from CloudWatch to SNS
 # See: https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-receive-sns-for-alarm-trigger/
 resource "aws_kms_key" "securityhub-alarms" {


### PR DESCRIPTION
Fixing this issue - https://github.com/ministryofjustice/modernisation-platform/issues/7497

Tested in cooker-development after a terraform destroy, and on long-term-storage (not after a terraform destroy)

This module is now separate from other parts of baselines. Im not sure why I worked so hard to use the same key.


Removing the s3 replication is just tidying up, it was commented out.

Tested an alert here - https://moj.enterprise.slack.com/archives/C02PFCG8M1R/p1720789196088279