### PR TITLE
add condition to filter out ListDelegatedAdministrators messages

### DIFF
--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -73,7 +73,7 @@ resource "aws_sns_topic" "securityhub-alarms" {
 # 3.1 - Ensure a log metric filter and alarm exist for unauthorized API calls
 resource "aws_cloudwatch_log_metric_filter" "unauthorised-api-calls" {
   name           = "unauthorised-api-calls"
-  pattern        = "{($.errorCode=\"*UnauthorizedOperation\") || ($.errorCode=\"AccessDenied*\")}"
+  pattern        = "{($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\" && $.eventName != \"ListDelegatedAdministrators\")}"
   log_group_name = "cloudtrail"
 
   metric_transformation {


### PR DESCRIPTION
This PR is part of [this issue](https://github.com/ministryofjustice/modernisation-platform/issues/7406) tracked in the `modernisation-platform` repository.

We make use of the Terraform `aws_organizations_organization` data call to retrieve information about other accounts in the same organisation. However, when running this outside of either the root account or a delegated administrator, we trigger alerts for the `ListDelegatedAdministrators` event. This PR ceases the notification on these events.