### PR TITLE
Changes for a reduced pre prod backup

### DIFF
--- a/backup.tf
+++ b/backup.tf
@@ -31,6 +31,8 @@ resource "aws_iam_role_policy_attachment" "backupS3" {
 
 module "backup-ap-northeast-1" {
   for_each = contains(var.enabled_backup_regions, "ap-northeast-1") ? local.enabled : local.not_enabled
+  
+  reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
   source   = "./modules/backup"
   providers = {
     aws = aws.ap-northeast-1
@@ -41,6 +43,8 @@ module "backup-ap-northeast-1" {
 
 module "backup-ap-northeast-2" {
   for_each = contains(var.enabled_backup_regions, "ap-northeast-2") ? local.enabled : local.not_enabled
+
+  reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
   source   = "./modules/backup"
   providers = {
     aws = aws.ap-northeast-2
@@ -52,6 +56,7 @@ module "backup-ap-northeast-2" {
 module "backup-ap-south-1" {
   for_each = contains(var.enabled_backup_regions, "ap-south-1") ? local.enabled : local.not_enabled
 
+  reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
   source = "./modules/backup"
   providers = {
     aws = aws.ap-south-1
@@ -63,6 +68,7 @@ module "backup-ap-south-1" {
 module "backup-ap-southeast-1" {
   for_each = contains(var.enabled_backup_regions, "ap-southeast-1") ? local.enabled : local.not_enabled
 
+  reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
   source = "./modules/backup"
   providers = {
     aws = aws.ap-southeast-1
@@ -74,6 +80,7 @@ module "backup-ap-southeast-1" {
 module "backup-ap-southeast-2" {
   for_each = contains(var.enabled_backup_regions, "ap-southeast-2") ? local.enabled : local.not_enabled
 
+  reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
   source = "./modules/backup"
   providers = {
     aws = aws.ap-southeast-2
@@ -85,6 +92,7 @@ module "backup-ap-southeast-2" {
 module "backup-ca-central-1" {
   for_each = contains(var.enabled_backup_regions, "ca-central-1") ? local.enabled : local.not_enabled
 
+  reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
   source = "./modules/backup"
   providers = {
     aws = aws.ca-central-1
@@ -96,6 +104,7 @@ module "backup-ca-central-1" {
 module "backup-eu-central-1" {
   for_each = contains(var.enabled_backup_regions, "eu-central-1") ? local.enabled : local.not_enabled
 
+  reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
   source = "./modules/backup"
   providers = {
     aws = aws.eu-central-1
@@ -107,6 +116,7 @@ module "backup-eu-central-1" {
 module "backup-eu-north-1" {
   for_each = contains(var.enabled_backup_regions, "eu-north-1") ? local.enabled : local.not_enabled
 
+  reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
   source = "./modules/backup"
   providers = {
     aws = aws.eu-north-1
@@ -118,6 +128,7 @@ module "backup-eu-north-1" {
 module "backup-eu-west-1" {
   for_each = contains(var.enabled_backup_regions, "eu-west-1") ? local.enabled : local.not_enabled
 
+  reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
   source = "./modules/backup"
   providers = {
     aws = aws.eu-west-1
@@ -129,6 +140,7 @@ module "backup-eu-west-1" {
 module "backup-eu-west-2" {
   for_each = contains(var.enabled_backup_regions, "eu-west-2") ? local.enabled : local.not_enabled
 
+  reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
   source = "./modules/backup"
   providers = {
     aws = aws.eu-west-2
@@ -140,6 +152,7 @@ module "backup-eu-west-2" {
 module "backup-eu-west-3" {
   for_each = contains(var.enabled_backup_regions, "eu-west-3") ? local.enabled : local.not_enabled
 
+  reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
   source = "./modules/backup"
   providers = {
     aws = aws.eu-west-3
@@ -151,6 +164,7 @@ module "backup-eu-west-3" {
 module "backup-sa-east-1" {
   for_each = contains(var.enabled_backup_regions, "sa-east-1") ? local.enabled : local.not_enabled
 
+  reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
   source = "./modules/backup"
   providers = {
     aws = aws.sa-east-1
@@ -162,6 +176,7 @@ module "backup-sa-east-1" {
 module "backup-us-east-1" {
   for_each = contains(var.enabled_backup_regions, "us-east-1") ? local.enabled : local.not_enabled
 
+  reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
   source = "./modules/backup"
   providers = {
     aws = aws.us-east-1
@@ -173,6 +188,7 @@ module "backup-us-east-1" {
 module "backup-us-east-2" {
   for_each = contains(var.enabled_backup_regions, "us-east-2") ? local.enabled : local.not_enabled
 
+  reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
   source = "./modules/backup"
   providers = {
     aws = aws.us-east-2
@@ -184,6 +200,7 @@ module "backup-us-east-2" {
 module "backup-us-west-1" {
   for_each = contains(var.enabled_backup_regions, "us-west-1") ? local.enabled : local.not_enabled
 
+  reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
   source = "./modules/backup"
   providers = {
     aws = aws.us-west-1
@@ -195,6 +212,7 @@ module "backup-us-west-1" {
 module "backup-us-west-2" {
   for_each = contains(var.enabled_backup_regions, "us-west-2") ? local.enabled : local.not_enabled
 
+  reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
   source = "./modules/backup"
   providers = {
     aws = aws.us-west-2

--- a/backup.tf
+++ b/backup.tf
@@ -31,9 +31,9 @@ resource "aws_iam_role_policy_attachment" "backupS3" {
 
 module "backup-ap-northeast-1" {
   for_each = contains(var.enabled_backup_regions, "ap-northeast-1") ? local.enabled : local.not_enabled
-  
+
   reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
-  source   = "./modules/backup"
+  source                           = "./modules/backup"
   providers = {
     aws = aws.ap-northeast-1
   }
@@ -45,7 +45,7 @@ module "backup-ap-northeast-2" {
   for_each = contains(var.enabled_backup_regions, "ap-northeast-2") ? local.enabled : local.not_enabled
 
   reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
-  source   = "./modules/backup"
+  source                           = "./modules/backup"
   providers = {
     aws = aws.ap-northeast-2
   }
@@ -57,7 +57,7 @@ module "backup-ap-south-1" {
   for_each = contains(var.enabled_backup_regions, "ap-south-1") ? local.enabled : local.not_enabled
 
   reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
-  source = "./modules/backup"
+  source                           = "./modules/backup"
   providers = {
     aws = aws.ap-south-1
   }
@@ -69,7 +69,7 @@ module "backup-ap-southeast-1" {
   for_each = contains(var.enabled_backup_regions, "ap-southeast-1") ? local.enabled : local.not_enabled
 
   reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
-  source = "./modules/backup"
+  source                           = "./modules/backup"
   providers = {
     aws = aws.ap-southeast-1
   }
@@ -81,7 +81,7 @@ module "backup-ap-southeast-2" {
   for_each = contains(var.enabled_backup_regions, "ap-southeast-2") ? local.enabled : local.not_enabled
 
   reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
-  source = "./modules/backup"
+  source                           = "./modules/backup"
   providers = {
     aws = aws.ap-southeast-2
   }
@@ -93,7 +93,7 @@ module "backup-ca-central-1" {
   for_each = contains(var.enabled_backup_regions, "ca-central-1") ? local.enabled : local.not_enabled
 
   reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
-  source = "./modules/backup"
+  source                           = "./modules/backup"
   providers = {
     aws = aws.ca-central-1
   }
@@ -105,7 +105,7 @@ module "backup-eu-central-1" {
   for_each = contains(var.enabled_backup_regions, "eu-central-1") ? local.enabled : local.not_enabled
 
   reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
-  source = "./modules/backup"
+  source                           = "./modules/backup"
   providers = {
     aws = aws.eu-central-1
   }
@@ -117,7 +117,7 @@ module "backup-eu-north-1" {
   for_each = contains(var.enabled_backup_regions, "eu-north-1") ? local.enabled : local.not_enabled
 
   reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
-  source = "./modules/backup"
+  source                           = "./modules/backup"
   providers = {
     aws = aws.eu-north-1
   }
@@ -129,7 +129,7 @@ module "backup-eu-west-1" {
   for_each = contains(var.enabled_backup_regions, "eu-west-1") ? local.enabled : local.not_enabled
 
   reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
-  source = "./modules/backup"
+  source                           = "./modules/backup"
   providers = {
     aws = aws.eu-west-1
   }
@@ -141,7 +141,7 @@ module "backup-eu-west-2" {
   for_each = contains(var.enabled_backup_regions, "eu-west-2") ? local.enabled : local.not_enabled
 
   reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
-  source = "./modules/backup"
+  source                           = "./modules/backup"
   providers = {
     aws = aws.eu-west-2
   }
@@ -153,7 +153,7 @@ module "backup-eu-west-3" {
   for_each = contains(var.enabled_backup_regions, "eu-west-3") ? local.enabled : local.not_enabled
 
   reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
-  source = "./modules/backup"
+  source                           = "./modules/backup"
   providers = {
     aws = aws.eu-west-3
   }
@@ -165,7 +165,7 @@ module "backup-sa-east-1" {
   for_each = contains(var.enabled_backup_regions, "sa-east-1") ? local.enabled : local.not_enabled
 
   reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
-  source = "./modules/backup"
+  source                           = "./modules/backup"
   providers = {
     aws = aws.sa-east-1
   }
@@ -177,7 +177,7 @@ module "backup-us-east-1" {
   for_each = contains(var.enabled_backup_regions, "us-east-1") ? local.enabled : local.not_enabled
 
   reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
-  source = "./modules/backup"
+  source                           = "./modules/backup"
   providers = {
     aws = aws.us-east-1
   }
@@ -189,7 +189,7 @@ module "backup-us-east-2" {
   for_each = contains(var.enabled_backup_regions, "us-east-2") ? local.enabled : local.not_enabled
 
   reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
-  source = "./modules/backup"
+  source                           = "./modules/backup"
   providers = {
     aws = aws.us-east-2
   }
@@ -201,7 +201,7 @@ module "backup-us-west-1" {
   for_each = contains(var.enabled_backup_regions, "us-west-1") ? local.enabled : local.not_enabled
 
   reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
-  source = "./modules/backup"
+  source                           = "./modules/backup"
   providers = {
     aws = aws.us-west-1
   }
@@ -213,7 +213,7 @@ module "backup-us-west-2" {
   for_each = contains(var.enabled_backup_regions, "us-west-2") ? local.enabled : local.not_enabled
 
   reduced_preprod_backup_retention = var.reduced_preprod_backup_retention
-  source = "./modules/backup"
+  source                           = "./modules/backup"
   providers = {
     aws = aws.us-west-2
   }

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -154,7 +154,7 @@ resource "aws_backup_plan" "non_production" {
     completion_window = (6 * 60)
 
     lifecycle {
-      delete_after = var.non_prod_backup_retention_days
+      delete_after = var.reduced_preprod_backup_retention ? 7 : var.non_prod_backup_retention_days
     }
   }
 

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -63,7 +63,7 @@ variable "max_vault_retention_days" {
 }
 
 variable "min_vault_retention_days" {
-  default     = 30
+  default     = 7
   description = "AWS Backup Vault config value for the min retention in days"
   type        = number
 }
@@ -72,4 +72,10 @@ variable "aws_kms_alias_name" {
   default     = "alias/backup-alarms-key-multi-region"
   description = "KMS key name for backup alarms"
   type        = string
+}
+
+
+variable "reduced_preprod_backup_retention" {
+  description = "AWS Backup variable, if true, pre prod only retains 7 days of backups"
+  type        = bool
 }

--- a/test/backup-test/main.tf
+++ b/test/backup-test/main.tf
@@ -12,6 +12,7 @@ module "backup-test" {
   min_vault_retention_days             = var.min_vault_retention_days
   backup_vault_lock_sns_topic_name     = var.backup_vault_lock_sns_topic_name
   aws_kms_alias_name                   = var.aws_kms_alias_name
+  reduced_preprod_backup_retention     = var.reduced_preprod_backup_retention
 }
 
 /*

--- a/test/backup-test/variables.tf
+++ b/test/backup-test/variables.tf
@@ -61,3 +61,9 @@ variable "aws_kms_alias_name" {
   description = "KMS key name for backup alarms"
   type        = string
 }
+
+variable "reduced_preprod_backup_retention" {
+  description = "AWS Backup variable, if true, pre prod only retains 7 days of backups"
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -61,3 +61,8 @@ variable "enabled_imdsv2_regions" {
   description = "Regions to enable IMDSv2 in"
   type        = list(string)
 }
+
+variable "reduced_preprod_backup_retention" {
+  description = "AWS Backup variable, if true, pre prod only retains 7 days of backups"
+  type        = bool
+}


### PR DESCRIPTION
Goes hand in hand with https://github.com/ministryofjustice/modernisation-platform/pull/7530 (that plan below is from a local run with the baselines version here)

This change means you can pass in names of services, and the test environments that use AWS Backup will not only have a retained days as 7.

```
Terraform will perform the following actions:

  # module.baselines.module.backup-eu-central-1["enabled"].aws_backup_plan.non_production will be updated in-place
  ~ resource "aws_backup_plan" "non_production" {
        id       = "b0ac326e-3243-410c-a03d-7ade78045cbf"
        name     = "backup-daily-cold-storage-monthly-retain-30-days"
        tags     = {
            "application"   = "Modernisation Platform: Environments Management"
            "business-unit" = "Platforms"
            "component"     = "secure-baselines"
            "is-production" = "true"
            "owner"         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
            "source-code"   = "https://github.com/ministryofjustice/modernisation-platform/tree/main/terraform/environments/bootstrap/secure-baselines"
        }
        # (3 unchanged attributes hidden)

      - rule {
          - completion_window        = 360 -> null
          - enable_continuous_backup = false -> null
          - recovery_point_tags      = {} -> null
          - rule_name                = "backup-daily-cold-storage-monthly-retain-30-days" -> null
          - schedule                 = "cron(30 0 * * ? *)" -> null
          - start_window             = 60 -> null
          - target_vault_name        = "everything" -> null

          - lifecycle {
              - cold_storage_after                        = 0 -> null
              - delete_after                              = 30 -> null
              - opt_in_to_archive_for_supported_resources = false -> null
            }
        }
      + rule {
          + completion_window        = 360
          + enable_continuous_backup = false
          + rule_name                = "backup-daily-cold-storage-monthly-retain-30-days"
          + schedule                 = "cron(30 0 * * ? *)"
          + start_window             = 60
          + target_vault_name        = "everything"

          + lifecycle {
              + delete_after                              = 7
              + opt_in_to_archive_for_supported_resources = (known after apply)
            }
        }

        # (1 unchanged block hidden)
    }

  # module.baselines.module.backup-eu-central-1["enabled"].aws_backup_vault_lock_configuration.default[0] must be replaced
-/+ resource "aws_backup_vault_lock_configuration" "default" {
      ~ backup_vault_arn   = "arn:aws:backup:eu-central-1:916521471442:backup-vault:everything" -> (known after apply)
      ~ id                 = "everything" -> (known after apply)
      ~ min_retention_days = 30 -> 7 # forces replacement
        # (2 unchanged attributes hidden)
    }

  # module.baselines.module.backup-eu-west-1["enabled"].aws_backup_plan.non_production will be updated in-place
  ~ resource "aws_backup_plan" "non_production" {
        id       = "1e9888ed-41d6-498a-a379-a6be21b230a1"
        name     = "backup-daily-cold-storage-monthly-retain-30-days"
        tags     = {
            "application"   = "Modernisation Platform: Environments Management"
            "business-unit" = "Platforms"
            "component"     = "secure-baselines"
            "is-production" = "true"
            "owner"         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
            "source-code"   = "https://github.com/ministryofjustice/modernisation-platform/tree/main/terraform/environments/bootstrap/secure-baselines"
        }
        # (3 unchanged attributes hidden)

      - rule {
          - completion_window        = 360 -> null
          - enable_continuous_backup = false -> null
          - recovery_point_tags      = {} -> null
          - rule_name                = "backup-daily-cold-storage-monthly-retain-30-days" -> null
          - schedule                 = "cron(30 0 * * ? *)" -> null
          - start_window             = 60 -> null
          - target_vault_name        = "everything" -> null

          - lifecycle {
              - cold_storage_after                        = 0 -> null
              - delete_after                              = 30 -> null
              - opt_in_to_archive_for_supported_resources = false -> null
            }
        }
      + rule {
          + completion_window        = 360
          + enable_continuous_backup = false
          + rule_name                = "backup-daily-cold-storage-monthly-retain-30-days"
          + schedule                 = "cron(30 0 * * ? *)"
          + start_window             = 60
          + target_vault_name        = "everything"

          + lifecycle {
              + delete_after                              = 7
              + opt_in_to_archive_for_supported_resources = (known after apply)
            }
        }

        # (1 unchanged block hidden)
    }

  # module.baselines.module.backup-eu-west-1["enabled"].aws_backup_vault_lock_configuration.default[0] must be replaced
-/+ resource "aws_backup_vault_lock_configuration" "default" {
      ~ backup_vault_arn   = "arn:aws:backup:eu-west-1:916521471442:backup-vault:everything" -> (known after apply)
      ~ id                 = "everything" -> (known after apply)
      ~ min_retention_days = 30 -> 7 # forces replacement
        # (2 unchanged attributes hidden)
    }

  # module.baselines.module.backup-eu-west-2["enabled"].aws_backup_plan.non_production will be updated in-place
  ~ resource "aws_backup_plan" "non_production" {
        id       = "f954aa8b-ee47-405f-b574-0ae2b570d8e9"
        name     = "backup-daily-cold-storage-monthly-retain-30-days"
        tags     = {
            "application"   = "Modernisation Platform: Environments Management"
            "business-unit" = "Platforms"
            "component"     = "secure-baselines"
            "is-production" = "true"
            "owner"         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
            "source-code"   = "https://github.com/ministryofjustice/modernisation-platform/tree/main/terraform/environments/bootstrap/secure-baselines"
        }
        # (3 unchanged attributes hidden)

      - rule {
          - completion_window        = 360 -> null
          - enable_continuous_backup = false -> null
          - recovery_point_tags      = {} -> null
          - rule_name                = "backup-daily-cold-storage-monthly-retain-30-days" -> null
          - schedule                 = "cron(30 0 * * ? *)" -> null
          - start_window             = 60 -> null
          - target_vault_name        = "everything" -> null

          - lifecycle {
              - cold_storage_after                        = 0 -> null
              - delete_after                              = 30 -> null
              - opt_in_to_archive_for_supported_resources = false -> null
            }
        }
      + rule {
          + completion_window        = 360
          + enable_continuous_backup = false
          + rule_name                = "backup-daily-cold-storage-monthly-retain-30-days"
          + schedule                 = "cron(30 0 * * ? *)"
          + start_window             = 60
          + target_vault_name        = "everything"

          + lifecycle {
              + delete_after                              = 7
              + opt_in_to_archive_for_supported_resources = (known after apply)
            }
        }

        # (1 unchanged block hidden)
    }

  # module.baselines.module.backup-eu-west-2["enabled"].aws_backup_vault_lock_configuration.default[0] must be replaced
-/+ resource "aws_backup_vault_lock_configuration" "default" {
      ~ backup_vault_arn   = "arn:aws:backup:eu-west-2:916521471442:backup-vault:everything" -> (known after apply)
      ~ id                 = "everything" -> (known after apply)
      ~ min_retention_days = 30 -> 7 # forces replacement
        # (2 unchanged attributes hidden)
    }

  # module.baselines.module.backup-eu-west-3["enabled"].aws_backup_plan.non_production will be updated in-place
  ~ resource "aws_backup_plan" "non_production" {
        id       = "18a0ff46-daf3-428d-bb6a-3d400d56bd3a"
        name     = "backup-daily-cold-storage-monthly-retain-30-days"
        tags     = {
            "application"   = "Modernisation Platform: Environments Management"
            "business-unit" = "Platforms"
            "component"     = "secure-baselines"
            "is-production" = "true"
            "owner"         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
            "source-code"   = "https://github.com/ministryofjustice/modernisation-platform/tree/main/terraform/environments/bootstrap/secure-baselines"
        }
        # (3 unchanged attributes hidden)

      - rule {
          - completion_window        = 360 -> null
          - enable_continuous_backup = false -> null
          - recovery_point_tags      = {} -> null
          - rule_name                = "backup-daily-cold-storage-monthly-retain-30-days" -> null
          - schedule                 = "cron(30 0 * * ? *)" -> null
          - start_window             = 60 -> null
          - target_vault_name        = "everything" -> null

          - lifecycle {
              - cold_storage_after                        = 0 -> null
              - delete_after                              = 30 -> null
              - opt_in_to_archive_for_supported_resources = false -> null
            }
        }
      + rule {
          + completion_window        = 360
          + enable_continuous_backup = false
          + rule_name                = "backup-daily-cold-storage-monthly-retain-30-days"
          + schedule                 = "cron(30 0 * * ? *)"
          + start_window             = 60
          + target_vault_name        = "everything"

          + lifecycle {
              + delete_after                              = 7
              + opt_in_to_archive_for_supported_resources = (known after apply)
            }
        }

        # (1 unchanged block hidden)
    }

  # module.baselines.module.backup-eu-west-3["enabled"].aws_backup_vault_lock_configuration.default[0] must be replaced
-/+ resource "aws_backup_vault_lock_configuration" "default" {
      ~ backup_vault_arn   = "arn:aws:backup:eu-west-3:916521471442:backup-vault:everything" -> (known after apply)
      ~ id                 = "everything" -> (known after apply)
      ~ min_retention_days = 30 -> 7 # forces replacement
        # (2 unchanged attributes hidden)
    }

  # module.baselines.module.backup-us-east-1["enabled"].aws_backup_plan.non_production will be updated in-place
  ~ resource "aws_backup_plan" "non_production" {
        id       = "238a2e12-9eaf-4ea7-a13c-aa3c1012a932"
        name     = "backup-daily-cold-storage-monthly-retain-30-days"
        tags     = {
            "application"   = "Modernisation Platform: Environments Management"
            "business-unit" = "Platforms"
            "component"     = "secure-baselines"
            "is-production" = "true"
            "owner"         = "Modernisation Platform: modernisation-platform@digital.justice.gov.uk"
            "source-code"   = "https://github.com/ministryofjustice/modernisation-platform/tree/main/terraform/environments/bootstrap/secure-baselines"
        }
        # (3 unchanged attributes hidden)

      - rule {
          - completion_window        = 360 -> null
          - enable_continuous_backup = false -> null
          - recovery_point_tags      = {} -> null
          - rule_name                = "backup-daily-cold-storage-monthly-retain-30-days" -> null
          - schedule                 = "cron(30 0 * * ? *)" -> null
          - start_window             = 60 -> null
          - target_vault_name        = "everything" -> null

          - lifecycle {
              - cold_storage_after                        = 0 -> null
              - delete_after                              = 30 -> null
              - opt_in_to_archive_for_supported_resources = false -> null
            }
        }
      + rule {
          + completion_window        = 360
          + enable_continuous_backup = false
          + rule_name                = "backup-daily-cold-storage-monthly-retain-30-days"
          + schedule                 = "cron(30 0 * * ? *)"
          + start_window             = 60
          + target_vault_name        = "everything"

          + lifecycle {
              + delete_after                              = 7
              + opt_in_to_archive_for_supported_resources = (known after apply)
            }
        }

        # (1 unchanged block hidden)
    }

  # module.baselines.module.backup-us-east-1["enabled"].aws_backup_vault_lock_configuration.default[0] must be replaced
-/+ resource "aws_backup_vault_lock_configuration" "default" {
      ~ backup_vault_arn   = "arn:aws:backup:us-east-1:916521471442:backup-vault:everything" -> (known after apply)
      ~ id                 = "everything" -> (known after apply)
      ~ min_retention_days = 30 -> 7 # forces replacement
        # (2 unchanged attributes hidden)
    }

Plan: 5 to add, 5 to change, 5 to destroy.

```