### PR TITLE
New Alarms for secure baseline

### DIFF
--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -533,7 +533,6 @@ resource "aws_cloudwatch_metric_alarm" "ErrorPortAllocation" {
 
 # NAT PacketsDropCount alarm
 resource "aws_cloudwatch_metric_alarm" "nat_packets_drop_count" {
-  count               = length(data.aws_nat_gateways.all.id)
   alarm_name          = "NAT-PacketsDropCount"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 5
@@ -545,7 +544,7 @@ resource "aws_cloudwatch_metric_alarm" "nat_packets_drop_count" {
   alarm_description   = "NAT Gateway is dropping packets. This might indicate an issue with the NAT Gateway."
 
   dimensions = {
-    NatGatewayId = data.aws_nat_gateways.all.id[count.index]
+    NatGatewayId = data.aws_nat_gateways.all.id
   }
 
   alarm_actions = [aws_sns_topic.securityhub-alarms.arn]
@@ -554,7 +553,6 @@ resource "aws_cloudwatch_metric_alarm" "nat_packets_drop_count" {
 
 
 resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count" {
-  count               = length(data.aws_vpc_endpoint.privatelink_endpoints.id)
   alarm_name          = "PrivateLink-NewFlowCount"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
@@ -566,7 +564,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count" {
   alarm_description   = "This alarm monitors the number of new flows or connections established through the VPC endpoint. A sudden increase in new flows might indicate a potential security issue or unexpected traffic pattern."
 
   dimensions = {
-    EndpointId = data.aws_vpc_endpoint.privatelink_endpoints.id[count.index]
+    EndpointId = data.aws_vpc_endpoint.privatelink_endpoints.id
   }
 
   alarm_actions = [aws_sns_topic.securityhub-alarms.arn]
@@ -575,7 +573,6 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "privatelink_active_flow_count" {
-  count               = length(data.aws_vpc_endpoint.privatelink_endpoints.id)
   alarm_name          = "PrivateLink-ActiveFlowCount"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
@@ -587,7 +584,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_active_flow_count" {
   alarm_description   = "This alarm monitors the number of concurrent active flows or connections through the VPC endpoint. A high number of active flows might indicate high resource utilization or potential performance issues."
 
   dimensions = {
-    EndpointId = data.aws_vpc_endpoint.privatelink_endpoints.id[count.index]
+    EndpointId = data.aws_vpc_endpoint.privatelink_endpoints.id
   }
 
   alarm_actions = [aws_sns_topic.securityhub-alarms.arn]
@@ -597,7 +594,6 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_active_flow_count" {
 
 # New Connection Count Alarm
 resource "aws_cloudwatch_metric_alarm" "privatelink_new_connection_count" {
-  count               = length(data.aws_vpc_endpoint_service.privatelink_services.service_name)
   alarm_name          = "PrivateLink-NewConnectionCount"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
@@ -609,7 +605,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_new_connection_count" {
   alarm_description   = "This alarm monitors the number of new connections established to the VPC Endpoint Service. A sudden increase might indicate unusual activity."
 
   dimensions = {
-    ServiceName = data.aws_vpc_endpoint_service.privatelink_services.service_name[count.index]
+    ServiceName = data.aws_vpc_endpoint_service.privatelink_services.service_name
   }
 
   alarm_actions = [aws_sns_topic.securityhub-alarms.arn]
@@ -619,7 +615,6 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_new_connection_count" {
 
 # Active Connection Count Alarm
 resource "aws_cloudwatch_metric_alarm" "privatelink_active_connection_count" {
-  count               = length(data.aws_vpc_endpoint_service.privatelink_services.service_name)
   alarm_name          = "PrivateLink-ActiveConnectionCount"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
@@ -631,7 +626,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_active_connection_count" {
   alarm_description   = "This alarm monitors the number of active connections to the VPC Endpoint Service. A high number might indicate high resource utilization."
 
   dimensions = {
-    ServiceName = data.aws_vpc_endpoint_service.privatelink_services.service_name[count.index]
+    ServiceName = data.aws_vpc_endpoint_service.privatelink_services.service_name
   }
 
   alarm_actions = [aws_sns_topic.securityhub-alarms.arn]

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -575,7 +575,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "privatelink_active_flow_count" {
-  count = length(data.aws_vpc_endpoints.privatelink_endpoints.ids)
+  count               = length(data.aws_vpc_endpoints.privatelink_endpoints.ids)
   alarm_name          = "PrivateLink-ActiveFlowCount-${data.aws_vpc_endpoints.privatelink_endpoints.ids[count.index]}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -11,8 +11,8 @@ data "aws_vpc_endpoint_service" "privatelink_services" {
 data "aws_nat_gateways" "all" {}
 
 locals {
-  nat_gateways_id = toset(data.aws_nat_gateways.all.id)
-  vpc_endpoint = toset(data.aws_vpc_endpoint.privatelink_endpoints.id)
+  nat_gateways_id      = toset(data.aws_nat_gateways.all.id)
+  vpc_endpoint         = toset(data.aws_vpc_endpoint.privatelink_endpoints.id)
   vpc_endpoint_service = toset(data.aws_vpc_endpoint_service.privatelink_services.id)
 }
 

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -575,8 +575,8 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "privatelink_active_flow_count" {
-  count               = length(data.aws_vpc_endpoints.privatelink_endpoints.id)
-  alarm_name          = "PrivateLink-ActiveFlowCount-${data.aws_vpc_endpoints.privatelink_endpoints.id[count.index]}"
+  count               = length(data.aws_vpc_endpoint.privatelink_endpoints.id)
+  alarm_name          = "PrivateLink-ActiveFlowCount-${data.aws_vpc_endpoint.privatelink_endpoints.id[count.index]}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
   metric_name         = "ActiveFlowCount"

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -554,7 +554,7 @@ resource "aws_cloudwatch_metric_alarm" "nat_packets_drop_count" {
 
 
 resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count" {
-  count = length(data.aws_vpc_endpoints.privatelink_endpoints.ids)
+  count               = length(data.aws_vpc_endpoints.privatelink_endpoints.ids)
   alarm_name          = "PrivateLink-NewFlowCount-${data.aws_vpc_endpoints.privatelink_endpoints.ids[count.index]}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
@@ -575,7 +575,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "privatelink_active_flow_count" {
-  count = length(data.aws_vpc_endpoints.privatelink_endpoints.ids)
+  count               = length(data.aws_vpc_endpoints.privatelink_endpoints.ids)
   alarm_name          = "PrivateLink-ActiveFlowCount-${data.aws_vpc_endpoints.privatelink_endpoints.ids[count.index]}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -1,6 +1,6 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_vpc_endpoints" "all_privatelink_endpoints" {
+data "aws_vpc_endpoint" "all_privatelink_endpoints" {
   # No filters here means it will fetch all VPC endpoints
 }
 data "aws_vpc_endpoint_service" "privatelink_services" {
@@ -554,8 +554,8 @@ resource "aws_cloudwatch_metric_alarm" "nat_packets_drop_count" {
 
 
 resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count" {
-  count               = length(data.aws_vpc_endpoints.privatelink_endpoints.ids)
-  alarm_name          = "PrivateLink-NewFlowCount-${data.aws_vpc_endpoints.privatelink_endpoints.ids[count.index]}"
+  count               = length(data.aws_vpc_endpoint.privatelink_endpoints.ids)
+  alarm_name          = "PrivateLink-NewFlowCount-${data.aws_vpc_endpoint.privatelink_endpoints.ids[count.index]}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
   metric_name         = "NewFlowCount"
@@ -566,7 +566,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count" {
   alarm_description   = "This alarm monitors the number of new flows or connections established through the VPC endpoint. A sudden increase in new flows might indicate a potential security issue or unexpected traffic pattern."
 
   dimensions = {
-    EndpointId = data.aws_vpc_endpoints.privatelink_endpoints.ids[count.index]
+    EndpointId = data.aws_vpc_endpoint.privatelink_endpoints.ids[count.index]
   }
 
   alarm_actions = [aws_sns_topic.securityhub-alarms.arn]
@@ -575,7 +575,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "privatelink_active_flow_count" {
-  count               = length(data.aws_vpc_endpoints.privatelink_endpoints.ids)
+  count = length(data.aws_vpc_endpoints.privatelink_endpoints.ids)
   alarm_name          = "PrivateLink-ActiveFlowCount-${data.aws_vpc_endpoints.privatelink_endpoints.ids[count.index]}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
@@ -587,7 +587,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_active_flow_count" {
   alarm_description   = "This alarm monitors the number of concurrent active flows or connections through the VPC endpoint. A high number of active flows might indicate high resource utilization or potential performance issues."
 
   dimensions = {
-    EndpointId = data.aws_vpc_endpoints.privatelink_endpoints.ids[count.index]
+    EndpointId = data.aws_vpc_endpoint.privatelink_endpoints.ids[count.index]
   }
 
   alarm_actions = [aws_sns_topic.securityhub-alarms.arn]
@@ -609,7 +609,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_new_connection_count" {
   alarm_description   = "This alarm monitors the number of new connections established to the VPC Endpoint Service. A sudden increase might indicate unusual activity."
 
   dimensions = {
-    ServiceName = data.aws_vpc_endpoint_service.privatelink_services.service_names[count.index]
+    ServiceName = data.aws_vpc_endpoint_service.privatelink_services.service_name[count.index]
   }
 
   alarm_actions = [aws_sns_topic.securityhub-alarms.arn]
@@ -631,7 +631,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_active_connection_count" {
   alarm_description   = "This alarm monitors the number of active connections to the VPC Endpoint Service. A high number might indicate high resource utilization."
 
   dimensions = {
-    ServiceName = data.aws_vpc_endpoint_service.privatelink_services.service_names[count.index]
+    ServiceName = data.aws_vpc_endpoint_service.privatelink_services.service_name[count.index]
   }
 
   alarm_actions = [aws_sns_topic.securityhub-alarms.arn]

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -1,6 +1,6 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_vpc_endpoint" "all_privatelink_endpoints" {
+data "aws_vpc_endpoint" "privatelink_endpoints" {
   # No filters here means it will fetch all VPC endpoints
 }
 data "aws_vpc_endpoint_service" "privatelink_services" {

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -533,8 +533,8 @@ resource "aws_cloudwatch_metric_alarm" "ErrorPortAllocation" {
 
 # NAT PacketsDropCount alarm
 resource "aws_cloudwatch_metric_alarm" "nat_packets_drop_count" {
-  count               = length(data.aws_nat_gateways.all.ids)
-  alarm_name          = "NAT-PacketsDropCount-${data.aws_nat_gateways.all.ids[count.index]}"
+  count               = length(data.aws_nat_gateways.all.id)
+  alarm_name          = "NAT-PacketsDropCount-${data.aws_nat_gateways.all.id[count.index]}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 5
   metric_name         = "PacketsDropCount"
@@ -545,7 +545,7 @@ resource "aws_cloudwatch_metric_alarm" "nat_packets_drop_count" {
   alarm_description   = "NAT Gateway is dropping packets. This might indicate an issue with the NAT Gateway."
 
   dimensions = {
-    NatGatewayId = data.aws_nat_gateways.all.ids[count.index]
+    NatGatewayId = data.aws_nat_gateways.all.id[count.index]
   }
 
   alarm_actions = [aws_sns_topic.securityhub-alarms.arn]
@@ -554,8 +554,8 @@ resource "aws_cloudwatch_metric_alarm" "nat_packets_drop_count" {
 
 
 resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count" {
-  count               = length(data.aws_vpc_endpoint.privatelink_endpoints.ids)
-  alarm_name          = "PrivateLink-NewFlowCount-${data.aws_vpc_endpoint.privatelink_endpoints.ids[count.index]}"
+  count               = length(data.aws_vpc_endpoint.privatelink_endpoints.id)
+  alarm_name          = "PrivateLink-NewFlowCount-${data.aws_vpc_endpoint.privatelink_endpoints.id[count.index]}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
   metric_name         = "NewFlowCount"
@@ -566,7 +566,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count" {
   alarm_description   = "This alarm monitors the number of new flows or connections established through the VPC endpoint. A sudden increase in new flows might indicate a potential security issue or unexpected traffic pattern."
 
   dimensions = {
-    EndpointId = data.aws_vpc_endpoint.privatelink_endpoints.ids[count.index]
+    EndpointId = data.aws_vpc_endpoint.privatelink_endpoints.id[count.index]
   }
 
   alarm_actions = [aws_sns_topic.securityhub-alarms.arn]
@@ -575,8 +575,8 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "privatelink_active_flow_count" {
-  count               = length(data.aws_vpc_endpoints.privatelink_endpoints.ids)
-  alarm_name          = "PrivateLink-ActiveFlowCount-${data.aws_vpc_endpoints.privatelink_endpoints.ids[count.index]}"
+  count               = length(data.aws_vpc_endpoints.privatelink_endpoints.id)
+  alarm_name          = "PrivateLink-ActiveFlowCount-${data.aws_vpc_endpoints.privatelink_endpoints.id[count.index]}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
   metric_name         = "ActiveFlowCount"
@@ -587,7 +587,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_active_flow_count" {
   alarm_description   = "This alarm monitors the number of concurrent active flows or connections through the VPC endpoint. A high number of active flows might indicate high resource utilization or potential performance issues."
 
   dimensions = {
-    EndpointId = data.aws_vpc_endpoint.privatelink_endpoints.ids[count.index]
+    EndpointId = data.aws_vpc_endpoint.privatelink_endpoints.id[count.index]
   }
 
   alarm_actions = [aws_sns_topic.securityhub-alarms.arn]
@@ -597,8 +597,8 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_active_flow_count" {
 
 # New Connection Count Alarm
 resource "aws_cloudwatch_metric_alarm" "privatelink_new_connection_count" {
-  count               = length(data.aws_vpc_endpoint_service.privatelink_services.service_names)
-  alarm_name          = "PrivateLink-NewConnectionCount-${data.aws_vpc_endpoint_service.privatelink_services.service_names[count.index]}"
+  count               = length(data.aws_vpc_endpoint_service.privatelink_services.service_name)
+  alarm_name          = "PrivateLink-NewConnectionCount-${data.aws_vpc_endpoint_service.privatelink_services.service_name[count.index]}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
   metric_name         = "NewConnectionCount"
@@ -619,8 +619,8 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_new_connection_count" {
 
 # Active Connection Count Alarm
 resource "aws_cloudwatch_metric_alarm" "privatelink_active_connection_count" {
-  count               = length(data.aws_vpc_endpoint_service.privatelink_services.service_names)
-  alarm_name          = "PrivateLink-ActiveConnectionCount-${data.aws_vpc_endpoint_service.privatelink_services.service_names[count.index]}"
+  count               = length(data.aws_vpc_endpoint_service.privatelink_services.service_name)
+  alarm_name          = "PrivateLink-ActiveConnectionCount-${data.aws_vpc_endpoint_service.privatelink_services.service_name[count.index]}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
   metric_name         = "ActiveConnectionCount"

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -534,7 +534,7 @@ resource "aws_cloudwatch_metric_alarm" "ErrorPortAllocation" {
 # NAT PacketsDropCount alarm
 resource "aws_cloudwatch_metric_alarm" "nat_packets_drop_count" {
   count               = length(data.aws_nat_gateways.all.id)
-  alarm_name          = "NAT-PacketsDropCount-${data.aws_nat_gateways.all.id[count.index]}"
+  alarm_name          = "NAT-PacketsDropCount"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 5
   metric_name         = "PacketsDropCount"
@@ -555,7 +555,7 @@ resource "aws_cloudwatch_metric_alarm" "nat_packets_drop_count" {
 
 resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count" {
   count               = length(data.aws_vpc_endpoint.privatelink_endpoints.id)
-  alarm_name          = "PrivateLink-NewFlowCount-${data.aws_vpc_endpoint.privatelink_endpoints.id[count.index]}"
+  alarm_name          = "PrivateLink-NewFlowCount"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
   metric_name         = "NewFlowCount"
@@ -576,7 +576,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count" {
 
 resource "aws_cloudwatch_metric_alarm" "privatelink_active_flow_count" {
   count               = length(data.aws_vpc_endpoint.privatelink_endpoints.id)
-  alarm_name          = "PrivateLink-ActiveFlowCount-${data.aws_vpc_endpoint.privatelink_endpoints.id[count.index]}"
+  alarm_name          = "PrivateLink-ActiveFlowCount"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
   metric_name         = "ActiveFlowCount"
@@ -598,7 +598,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_active_flow_count" {
 # New Connection Count Alarm
 resource "aws_cloudwatch_metric_alarm" "privatelink_new_connection_count" {
   count               = length(data.aws_vpc_endpoint_service.privatelink_services.service_name)
-  alarm_name          = "PrivateLink-NewConnectionCount-${data.aws_vpc_endpoint_service.privatelink_services.service_name[count.index]}"
+  alarm_name          = "PrivateLink-NewConnectionCount"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
   metric_name         = "NewConnectionCount"
@@ -620,7 +620,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_new_connection_count" {
 # Active Connection Count Alarm
 resource "aws_cloudwatch_metric_alarm" "privatelink_active_connection_count" {
   count               = length(data.aws_vpc_endpoint_service.privatelink_services.service_name)
-  alarm_name          = "PrivateLink-ActiveConnectionCount-${data.aws_vpc_endpoint_service.privatelink_services.service_name[count.index]}"
+  alarm_name          = "PrivateLink-ActiveConnectionCount"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
   metric_name         = "ActiveConnectionCount"

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -526,7 +526,7 @@ resource "aws_cloudwatch_metric_alarm" "nat_packets_drop_count_all" {
   alarm_name          = "NAT-PacketsDropCount-AllGateways"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 5
-  threshold           = "100"  # Adjust this threshold as needed
+  threshold           = "100" # Adjust this threshold as needed
   alarm_description   = "NAT Gateways are dropping packets. This might indicate an issue with one or more NAT Gateways."
 
   metric_query {
@@ -553,7 +553,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count_all" {
   alarm_name          = "PrivateLink-NewFlowCount-AllEndpoints"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
-  threshold           = "100"  # Adjust this threshold as needed
+  threshold           = "100" # Adjust this threshold as needed
   alarm_description   = "This alarm monitors the total number of new flows across all VPC endpoints."
 
   metric_query {
@@ -581,7 +581,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_active_flow_count_all" {
   alarm_name          = "PrivateLink-ActiveFlowCount-AllEndpoints"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
-  threshold           = "1000"  # Adjust this threshold as needed
+  threshold           = "1000" # Adjust this threshold as needed
   alarm_description   = "This alarm monitors the total number of active flows across all VPC endpoints."
 
   metric_query {
@@ -610,7 +610,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_service_new_connection_count
   alarm_name          = "PrivateLink-Service-NewConnectionCount-AllServices"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
-  threshold           = "100"  # Adjust this threshold as needed
+  threshold           = "100" # Adjust this threshold as needed
   alarm_description   = "This alarm monitors the total number of new connections across all VPC Endpoint Services."
 
   metric_query {
@@ -638,7 +638,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_service_active_connection_co
   alarm_name          = "PrivateLink-Service-ActiveConnectionCount-AllServices"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
-  threshold           = "1000"  # Adjust this threshold as needed
+  threshold           = "1000" # Adjust this threshold as needed
   alarm_description   = "This alarm monitors the total number of active connections across all VPC Endpoint Services."
 
   metric_query {


### PR DESCRIPTION
As a continuation of https://github.com/ministryofjustice/modernisation-platform/issues/1522
https://github.com/ministryofjustice/modernisation-platform/issues/1522
There are three things we can add to monitoring for the modernisation platform the first two are new cloud watch alarms based on aws documentation and the a third would be to add vpc flow logs to the modernisation platform transit gateway and adding monitoring to the cloud watch to monitor for low traffic on the link

This PR Adds in the new alarms