### PR TITLE
Remove NAT alarms

### DIFF
--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -491,64 +491,7 @@ resource "aws_cloudwatch_metric_alarm" "vpc-changes" {
   tags = var.tags
 }
 
-resource "aws_cloudwatch_log_metric_filter" "NATGatewayErrorPortAllocation" {
-  name           = var.error_port_allocation_metric_filter_name
-  pattern        = "{ $.eventSource = \"ec2.amazonaws.com\" && $.eventName = \"CreateNatGateway\" && $.errorCode = \"*\" && $.errorMessage = \"*Port Allocation*\" }"
-  log_group_name = "cloudtrail"
 
-  metric_transformation {
-    name      = "ErrorPortAllocation"
-    namespace = "NAT/Gateway"
-    value     = "1"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "ErrorPortAllocation" {
-  alarm_name        = var.error_port_allocation_alarm_name
-  alarm_description = "This alarm detects when the NAT Gateway is unable to allocate ports to new connections."
-  alarm_actions     = [aws_sns_topic.securityhub-alarms.arn]
-
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "ErrorPortAllocation"
-  namespace           = "NAT/Gateway"
-  period              = "300"
-  statistic           = "Sum"
-  threshold           = "0"
-  treat_missing_data  = "notBreaching"
-
-  tags = var.tags
-}
-
-
-# NAT PacketsDropCount alarm
-resource "aws_cloudwatch_metric_alarm" "nat_packets_drop_count_all" {
-  alarm_name          = var.nat_packets_drop_count_all_alarm_name
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 5
-  threshold           = "100" # Adjust this threshold as needed
-  alarm_description   = "NAT Gateways are dropping packets. This might indicate an issue with one or more NAT Gateways."
-
-  metric_query {
-    id          = "e1"
-    expression  = "SUM(METRICS())"
-    label       = "Total Dropped Packets"
-    return_data = "true"
-  }
-
-  metric_query {
-    id = "m1"
-    metric {
-      metric_name = "PacketsDropCount"
-      namespace   = "AWS/NATGateway"
-      period      = 60
-      stat        = "Sum"
-    }
-  }
-
-  alarm_actions = [aws_sns_topic.securityhub-alarms.arn]
-  tags          = var.tags
-}
 resource "aws_cloudwatch_metric_alarm" "privatelink_new_flow_count_all" {
   alarm_name          = var.privatelink_new_flow_count_all_alarm_name
   comparison_operator = "GreaterThanThreshold"

--- a/modules/securityhub-alarms/outputs.tf
+++ b/modules/securityhub-alarms/outputs.tf
@@ -162,21 +162,6 @@ output "vpc_changes_alarm_arn" {
   description = "The ARN of the CloudWatch alarm for VPC changes"
 }
 
-output "nat_gateway_error_port_allocation_metric_filter_id" {
-  description = "The ID of the CloudWatch Log Metric Filter for NAT Gateway Error Port Allocation"
-  value       = aws_cloudwatch_log_metric_filter.NATGatewayErrorPortAllocation.id
-}
-
-output "nat_gateway_error_port_allocation_alarm_arn" {
-  description = "The ARN of the CloudWatch Alarm for NAT Gateway Error Port Allocation"
-  value       = aws_cloudwatch_metric_alarm.ErrorPortAllocation.arn
-}
-
-output "nat_packets_drop_count_alarm_arn" {
-  description = "The ARN of the CloudWatch Alarm for NAT Packets Drop Count"
-  value       = aws_cloudwatch_metric_alarm.nat_packets_drop_count_all.arn
-}
-
 output "privatelink_new_flow_count_alarm_arn" {
   description = "The ARN of the CloudWatch Alarm for PrivateLink New Flow Count"
   value       = aws_cloudwatch_metric_alarm.privatelink_new_flow_count_all.arn

--- a/test/baselines_test.go
+++ b/test/baselines_test.go
@@ -191,9 +191,6 @@ func TestTerraformSecurityHubAlarms(t *testing.T) {
 	RouteTableChangesMetricFilterName := fmt.Sprintf("route-table-changes-%s", uniqueId)
 	VpcChangesAlarmName := fmt.Sprintf("vpc-changes-%s", uniqueId)
 	VpcChangesMetricFilterName := fmt.Sprintf("vpc-changes-%s", uniqueId)
-	ErrorPortAllocationMetricFilterName := fmt.Sprintf("ErrorPortAllocation-%s", uniqueId)
-	ErrorPortAllocationAlarmName := fmt.Sprintf("NAT-Gateway-ErrorPortAllocation-%s", uniqueId)
-	NatPacketsDropCountAllAlarmName := fmt.Sprintf("NAT-PacketsDropCount-AllGateways-%s", uniqueId)
 	PrivatelinkNewFlowCountAllAlarmName := fmt.Sprintf("PrivateLink-NewFlowCount-AllEndpoints-%s", uniqueId)
 	PrivatelinkActiveFlowCountAllAlarmName := fmt.Sprintf("PrivateLink-ActiveFlowCount-AllEndpoints-%s", uniqueId)
 	PrivatelinkServiceNewConnectionCountAllAlarmName := fmt.Sprintf("PrivateLink-Service-NewConnectionCount-AllServices-%s", uniqueId)
@@ -234,9 +231,6 @@ func TestTerraformSecurityHubAlarms(t *testing.T) {
 			"route_table_changes_metric_filter_name":                     RouteTableChangesMetricFilterName,
 			"vpc_changes_alarm_name":                                     VpcChangesAlarmName,
 			"vpc_changes_metric_filter_name":                             VpcChangesMetricFilterName,
-			"error_port_allocation_metric_filter_name":                   ErrorPortAllocationMetricFilterName,
-			"error_port_allocation_alarm_name":                           ErrorPortAllocationAlarmName,
-			"nat_packets_drop_count_all_alarm_name":                      NatPacketsDropCountAllAlarmName,
 			"privatelink_new_flow_count_all_alarm_name":                  PrivatelinkNewFlowCountAllAlarmName,
 			"privatelink_active_flow_count_all_alarm_name":               PrivatelinkActiveFlowCountAllAlarmName,
 			"privatelink_service_new_connection_count_all_alarm_name":    PrivatelinkServiceNewConnectionCountAllAlarmName,
@@ -288,9 +282,6 @@ func TestTerraformSecurityHubAlarms(t *testing.T) {
 	RouteTableChangesAlarmArn := terraform.Output(t, terraformOptions, "route_table_changes_alarm_arn")
 	VpcChangesMetricFilterId := terraform.Output(t, terraformOptions, "vpc_changes_metric_filter_id")
 	VpcChangesAlarmArn := terraform.Output(t, terraformOptions, "vpc_changes_alarm_arn")
-	ErrorPortAllocationMetricFilterId := terraform.Output(t, terraformOptions, "nat_gateway_error_port_allocation_metric_filter_id")
-	ErrorPortAllocationAlarmArn := terraform.Output(t, terraformOptions, "nat_gateway_error_port_allocation_alarm_arn")
-	NatPacketsDropCountAllAlarmArn := terraform.Output(t, terraformOptions, "nat_packets_drop_count_alarm_arn")
 	PrivatelinkNewFlowCountAllAlarmArn := terraform.Output(t, terraformOptions, "privatelink_new_flow_count_alarm_arn")
 	PrivatelinkActiveFlowCountAllAlarmArn := terraform.Output(t, terraformOptions, "privatelink_active_flow_count_alarm_arn")
 	PrivatelinkServiceNewConnectionCountAllAlarmArn := terraform.Output(t, terraformOptions, "privatelink_service_new_connection_count_alarm_arn")
@@ -330,9 +321,6 @@ func TestTerraformSecurityHubAlarms(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:cloudwatch:eu-west-2:[0-9]{12}:alarm:`+RouteTableChangesAlarmName), RouteTableChangesAlarmArn)
 	assert.Regexp(t, regexp.MustCompile(VpcChangesMetricFilterName), VpcChangesMetricFilterId)
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:cloudwatch:eu-west-2:[0-9]{12}:alarm:`+VpcChangesAlarmName), VpcChangesAlarmArn)
-	assert.Regexp(t, regexp.MustCompile(ErrorPortAllocationMetricFilterName), ErrorPortAllocationMetricFilterId)
-	assert.Regexp(t, regexp.MustCompile(`^arn:aws:cloudwatch:eu-west-2:[0-9]{12}:alarm:`+ErrorPortAllocationAlarmName), ErrorPortAllocationAlarmArn)
-	assert.Regexp(t, regexp.MustCompile(`^arn:aws:cloudwatch:eu-west-2:[0-9]{12}:alarm:`+NatPacketsDropCountAllAlarmName), NatPacketsDropCountAllAlarmArn)
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:cloudwatch:eu-west-2:[0-9]{12}:alarm:`+PrivatelinkNewFlowCountAllAlarmName), PrivatelinkNewFlowCountAllAlarmArn)
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:cloudwatch:eu-west-2:[0-9]{12}:alarm:`+PrivatelinkActiveFlowCountAllAlarmName), PrivatelinkActiveFlowCountAllAlarmArn)
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:cloudwatch:eu-west-2:[0-9]{12}:alarm:`+PrivatelinkServiceNewConnectionCountAllAlarmName), PrivatelinkServiceNewConnectionCountAllAlarmArn)

--- a/test/securityhub-alarms-test/main.tf
+++ b/test/securityhub-alarms-test/main.tf
@@ -31,9 +31,6 @@ module "securityhub-alarms-test" {
   route_table_changes_metric_filter_name                     = var.route_table_changes_metric_filter_name
   vpc_changes_alarm_name                                     = var.vpc_changes_alarm_name
   vpc_changes_metric_filter_name                             = var.vpc_changes_metric_filter_name
-  error_port_allocation_alarm_name                           = var.error_port_allocation_alarm_name
-  error_port_allocation_metric_filter_name                   = var.error_port_allocation_metric_filter_name
-  nat_packets_drop_count_all_alarm_name                      = var.nat_packets_drop_count_all_alarm_name
   privatelink_new_flow_count_all_alarm_name                  = var.privatelink_new_flow_count_all_alarm_name
   privatelink_active_flow_count_all_alarm_name               = var.privatelink_active_flow_count_all_alarm_name
   privatelink_service_new_connection_count_all_alarm_name    = var.privatelink_service_new_connection_count_all_alarm_name

--- a/test/securityhub-alarms-test/outputs.tf
+++ b/test/securityhub-alarms-test/outputs.tf
@@ -162,21 +162,6 @@ output "vpc_changes_alarm_arn" {
   description = "The ARN of the CloudWatch alarm for VPC changes"
 }
 
-output "nat_gateway_error_port_allocation_metric_filter_id" {
-  description = "The ID of the CloudWatch Log Metric Filter for NAT Gateway Error Port Allocation"
-  value       = module.securityhub-alarms-test.nat_gateway_error_port_allocation_metric_filter_id
-}
-
-output "nat_gateway_error_port_allocation_alarm_arn" {
-  description = "The ARN of the CloudWatch Alarm for NAT Gateway Error Port Allocation"
-  value       = module.securityhub-alarms-test.nat_gateway_error_port_allocation_alarm_arn
-}
-
-output "nat_packets_drop_count_alarm_arn" {
-  description = "The ARN of the CloudWatch Alarm for NAT Packets Drop Count"
-  value       = module.securityhub-alarms-test.nat_packets_drop_count_alarm_arn
-}
-
 output "privatelink_new_flow_count_alarm_arn" {
   description = "The ARN of the CloudWatch Alarm for PrivateLink New Flow Count"
   value       = module.securityhub-alarms-test.privatelink_new_flow_count_alarm_arn

--- a/test/securityhub-alarms-test/variables.tf
+++ b/test/securityhub-alarms-test/variables.tf
@@ -153,21 +153,6 @@ variable "vpc_changes_alarm_name" {
   type    = string
 }
 
-variable "error_port_allocation_metric_filter_name" {
-  default = "ErrorPortAllocation"
-  type    = string
-}
-
-variable "error_port_allocation_alarm_name" {
-  default = "NAT-Gateway-ErrorPortAllocation"
-  type    = string
-}
-
-variable "nat_packets_drop_count_all_alarm_name" {
-  default = "NAT-PacketsDropCount-AllGateways"
-  type    = string
-}
-
 variable "privatelink_new_flow_count_all_alarm_name" {
   default = "PrivateLink-NewFlowCount-AllEndpoints"
   type    = string


### PR DESCRIPTION
After talking with the team it has been pointed out that the NAT alarms are only required on one account the core network services account so we can remove them from the secure baselines and just create new code on the core account