### PR TITLE
Add admin role usage alarm and tests

### DIFF
--- a/modules/securityhub-alarms/outputs.tf
+++ b/modules/securityhub-alarms/outputs.tf
@@ -181,3 +181,13 @@ output "privatelink_service_active_connection_count_alarm_arn" {
   description = "The ARN of the CloudWatch Alarm for PrivateLink Service Active Connection Count"
   value       = aws_cloudwatch_metric_alarm.privatelink_service_active_connection_count_all.arn
 }
+
+output "admin_role_usage_metric_filter_id" {
+  value       = aws_cloudwatch_log_metric_filter.admin_role_usage.id
+  description = "The ID of the CloudWatch metric filter for admin role usage"
+}
+
+output "admin_role_usage_alarm_arn" {
+  description = "The ARN of the CloudWatch Alarm for admin role usage"
+  value       = aws_cloudwatch_metric_alarm.admin_role_usage.arn
+}

--- a/modules/securityhub-alarms/variables.tf
+++ b/modules/securityhub-alarms/variables.tf
@@ -193,3 +193,13 @@ variable "privatelink_service_active_connection_count_all_alarm_name" {
   default = "PrivateLink-Service-ActiveConnectionCount-AllServices"
   type    = string
 }
+
+variable "admin_role_usage_metric_filter_name" {
+  default = "admin-role-usage"
+  type    = string
+}
+
+variable "admin_role_usage_alarm_name" {
+  default = "admin-role-usage"
+  type    = string
+}

--- a/test/baselines_test.go
+++ b/test/baselines_test.go
@@ -195,6 +195,8 @@ func TestTerraformSecurityHubAlarms(t *testing.T) {
 	PrivatelinkActiveFlowCountAllAlarmName := fmt.Sprintf("PrivateLink-ActiveFlowCount-AllEndpoints-%s", uniqueId)
 	PrivatelinkServiceNewConnectionCountAllAlarmName := fmt.Sprintf("PrivateLink-Service-NewConnectionCount-AllServices-%s", uniqueId)
 	PrivatelinkServiceActiveConnectionCountAllAlarmName := fmt.Sprintf("PrivateLink-Service-ActiveConnectionCount-AllServices-%s", uniqueId)
+	AdminRoleUsageAlarmName := fmt.Sprintf("admin-role-usage-%s", uniqueId)
+	AdminRoleUsageMetricFilterName := fmt.Sprintf("admin-role-usage-%s", uniqueId)
 
 	terraformOptions := &terraform.Options{
 		TerraformDir: terraformDir,
@@ -235,6 +237,8 @@ func TestTerraformSecurityHubAlarms(t *testing.T) {
 			"privatelink_active_flow_count_all_alarm_name":               PrivatelinkActiveFlowCountAllAlarmName,
 			"privatelink_service_new_connection_count_all_alarm_name":    PrivatelinkServiceNewConnectionCountAllAlarmName,
 			"privatelink_service_active_connection_count_all_alarm_name": PrivatelinkServiceActiveConnectionCountAllAlarmName,
+			"admin_role_usage_alarm_name":                                AdminRoleUsageAlarmName,
+			"admin_role_usage_metric_filter_name":                        AdminRoleUsageMetricFilterName,
 		},
 	}
 	// Clean up resources with "terraform destroy" at the end of the test
@@ -286,6 +290,8 @@ func TestTerraformSecurityHubAlarms(t *testing.T) {
 	PrivatelinkActiveFlowCountAllAlarmArn := terraform.Output(t, terraformOptions, "privatelink_active_flow_count_alarm_arn")
 	PrivatelinkServiceNewConnectionCountAllAlarmArn := terraform.Output(t, terraformOptions, "privatelink_service_new_connection_count_alarm_arn")
 	PrivatelinkServiceActiveConnectionCountAllAlarmArn := terraform.Output(t, terraformOptions, "privatelink_service_active_connection_count_alarm_arn")
+	AdminRoleUsageAlarmArn := terraform.Output(t, terraformOptions, "admin_role_usage_alarm_arn")
+	AdminRoleUsageMetricFilterId := terraform.Output(t, terraformOptions, "admin_role_usage_metric_filter_id")
 
 	// Tests (comparing outputs to regex)
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:sns:eu-west-2:[0-9]{12}:securityhub-alarms-`+uniqueId), SnsTopicArn)
@@ -325,4 +331,6 @@ func TestTerraformSecurityHubAlarms(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:cloudwatch:eu-west-2:[0-9]{12}:alarm:`+PrivatelinkActiveFlowCountAllAlarmName), PrivatelinkActiveFlowCountAllAlarmArn)
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:cloudwatch:eu-west-2:[0-9]{12}:alarm:`+PrivatelinkServiceNewConnectionCountAllAlarmName), PrivatelinkServiceNewConnectionCountAllAlarmArn)
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:cloudwatch:eu-west-2:[0-9]{12}:alarm:`+PrivatelinkServiceActiveConnectionCountAllAlarmName), PrivatelinkServiceActiveConnectionCountAllAlarmArn)
+	assert.Regexp(t, regexp.MustCompile(AdminRoleUsageMetricFilterName), AdminRoleUsageMetricFilterId)
+	assert.Regexp(t, regexp.MustCompile(`^arn:aws:cloudwatch:eu-west-2:[0-9]{12}:alarm:`+AdminRoleUsageAlarmName), AdminRoleUsageAlarmArn)
 }

--- a/test/securityhub-alarms-test/main.tf
+++ b/test/securityhub-alarms-test/main.tf
@@ -35,4 +35,6 @@ module "securityhub-alarms-test" {
   privatelink_active_flow_count_all_alarm_name               = var.privatelink_active_flow_count_all_alarm_name
   privatelink_service_new_connection_count_all_alarm_name    = var.privatelink_service_new_connection_count_all_alarm_name
   privatelink_service_active_connection_count_all_alarm_name = var.privatelink_service_active_connection_count_all_alarm_name
+  admin_role_usage_alarm_name                                = var.admin_role_usage_alarm_name
+  admin_role_usage_metric_filter_name                        = var.admin_role_usage_metric_filter_name
 }

--- a/test/securityhub-alarms-test/outputs.tf
+++ b/test/securityhub-alarms-test/outputs.tf
@@ -181,3 +181,13 @@ output "privatelink_service_active_connection_count_alarm_arn" {
   description = "The ARN of the CloudWatch Alarm for PrivateLink Service Active Connection Count"
   value       = module.securityhub-alarms-test.privatelink_service_active_connection_count_alarm_arn
 }
+
+output "admin_role_usage_alarm_arn" {
+  description = "The ARN of teh CloudWatch Alarm for admin role usage"
+  value       = module.securityhub-alarms-test.admin_role_usage_alarm_arn
+}
+
+output "admin_role_usage_metric_filter_id" {
+  description = "The ID of the CloudWatch metric filter for admin role usage"
+  value       = module.securityhub-alarms-test.admin_role_usage_metric_filter_id
+}

--- a/test/securityhub-alarms-test/variables.tf
+++ b/test/securityhub-alarms-test/variables.tf
@@ -172,3 +172,13 @@ variable "privatelink_service_active_connection_count_all_alarm_name" {
   default = "PrivateLink-Service-ActiveConnectionCount-AllServices"
   type    = string
 }
+
+variable "admin_role_usage_metric_filter_name" {
+  default = "admin-role-usage"
+  type    = string
+}
+
+variable "admin_role_usage_alarm_name" {
+  default = "admin-role-usage"
+  type    = string
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/7437

## How does this PR fix the problem?

This adds a new alarm (and unit tests) which will trigger when anyone assumes the AdministratorAccess role in any MP accounts (Core/Member) in the MP low priority alerts channel.

## How has this been tested?

I started by reviewing cloudtrail logs when accessing the role and finding the best way to pinpoint when the role is being assumed. 
Then I created a new alarm and metric filter in the baselines module and manually applied it to the `core-shared-services` account (just because I needed an account that was already subscribed to the low priority slack alerts channel). I then assumed the admin role and observed that the alarm triggered and sent us a message. 

See an example of the alert being raised: 
https://moj-digital-tools.pagerduty.com/incidents/Q2NOMBHFB4MYRJ?utm_campaign=channel&utm_source=slack
https://mojdt.slack.com/archives/C02PFCG8M1R/p1724922501200269