### PR TITLE
Feature/7514 make kms key replicas

### DIFF
--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -23,6 +23,18 @@ resource "aws_kms_alias" "backup_alarms_multi_region" {
   target_key_id = aws_kms_key.backup_alarms_multi_region.id
 }
 
+resource "aws_kms_replica_key" "backup_alarms_multi_region_replica" {
+  description             = "AWS Secretsmanager CMK replica key"
+  deletion_window_in_days = 30
+  primary_key_arn         = aws_kms_key.backup_alarms_multi_region.arn
+  provider                = aws.modernisation-platform-eu-west-1
+}
+
+resource "aws_kms_alias" "backup_alarms_multi_region_replica" {
+  name          = "alias/backup_alarms-multi-region-replica"
+  target_key_id = aws_kms_replica_key.backup_alarms_multi_region_replica.id
+}
+
 data "aws_iam_policy_document" "backup-alarms-kms" {
 
   #checkov:skip=CKV_AWS_356: ""

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -74,6 +74,12 @@ variable "aws_kms_alias_name" {
   type        = string
 }
 
+variable "aws_kms_replica_alias_name" {
+  default     = "alias/backup-alarms-key-multi-region-replica"
+  description = "KMS key name for backup alarms"
+  type        = string
+}
+
 
 variable "reduced_preprod_backup_retention" {
   description = "AWS Backup variable, if true, pre prod only retains 7 days of backups"

--- a/modules/backup/versions.tf
+++ b/modules/backup/versions.tf
@@ -7,3 +7,8 @@ terraform {
   }
   required_version = ">= 1.0.1"
 }
+
+provider "aws" {
+  alias  = "modernisation-platform-eu-west-1"
+  region = "eu-west-1"
+}

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -30,6 +30,18 @@ resource "aws_kms_alias" "securityhub_alarms_multi_region" {
   target_key_id = aws_kms_key.securityhub_alarms_multi_region.id
 }
 
+resource "aws_kms_replica_key" "securityhub-alarms_multi_region_replica" {
+  description             = "AWS Secretsmanager CMK replica key"
+  deletion_window_in_days = 30
+  primary_key_arn         = aws_kms_key.securityhub-alarms_multi_region.arn
+  provider                = aws.modernisation-platform-eu-west-1
+}
+
+resource "aws_kms_alias" "securityhub-alarms_multi_region_replica" {
+  name          = var.securityhub_alarms_multi_region_kms_replica_name
+  target_key_id = aws_kms_replica_key.securityhub-alarms_multi_region_replica.id
+}
+
 data "aws_iam_policy_document" "securityhub-alarms-kms" {
 
   #checkov:skip=CKV_AWS_356: "Permissions required by sec-hub"
@@ -65,7 +77,7 @@ data "aws_iam_policy_document" "securityhub-alarms-kms" {
 # SNS topic, required for remediation
 resource "aws_sns_topic" "securityhub-alarms" {
   name              = var.securityhub_alarms_sns_topic_name
-  kms_master_key_id = aws_kms_key.securityhub-alarms.arn
+  kms_master_key_id = aws_kms_key.securityhub_alarms_multi_region.arn
   tags              = var.tags
 }
 

--- a/modules/securityhub-alarms/outputs.tf
+++ b/modules/securityhub-alarms/outputs.tf
@@ -22,6 +22,17 @@ output "securityhub_alarms_multi_region_kms_alias_arn" {
   description = "The ARN of the multi-region KMS alias for SecurityHub alarms"
 }
 
+output "securityhub_alarms_multi_region_kms_key_replica_arn" {
+  value       = aws_kms_key.securityhub_alarms_multi_region_replica.arn
+  description = "The ARN of the multi-region KMS key replica for SecurityHub alarms"
+}
+
+output "securityhub_alarms_multi_region_kms__replica_alias_arn" {
+  value       = aws_kms_alias.securityhub_alarms_multi_region_replica.arn
+  description = "The ARN of the multi-region KMS replica alias for SecurityHub alarms"
+}
+
+
 output "unauthorised_api_calls_metric_filter_id" {
   value       = aws_cloudwatch_log_metric_filter.unauthorised-api-calls.id
   description = "The ID of the CloudWatch metric filter for unauthorised API calls"

--- a/modules/securityhub-alarms/variables.tf
+++ b/modules/securityhub-alarms/variables.tf
@@ -14,6 +14,11 @@ variable "securityhub_alarms_multi_region_kms_name" {
   type    = string
 }
 
+variable "securityhub_alarms_multi_region_kms_replica_name" {
+  default = "alias/securityhub-alarms-key-multi-region-replica"
+  type    = string
+}
+
 variable "securityhub_alarms_sns_topic_name" {
   default = "securityhub-alarms"
   type    = string

--- a/modules/securityhub-alarms/versions.tf
+++ b/modules/securityhub-alarms/versions.tf
@@ -7,3 +7,8 @@ terraform {
   }
   required_version = ">= 1.0.1"
 }
+
+provider "aws" {
+  alias  = "modernisation-platform-eu-west-1"
+  region = "eu-west-1"
+}

--- a/test/backup-test/providers.tf
+++ b/test/backup-test/providers.tf
@@ -11,3 +11,8 @@ provider "aws" {
   alias  = "testing-ci-user"
   region = "eu-west-2"
 }
+
+provider "aws" {
+  alias  = "modernisation-platform-eu-west-1"
+  region = "eu-west-1"
+}

--- a/test/backup-test/variables.tf
+++ b/test/backup-test/variables.tf
@@ -62,6 +62,12 @@ variable "aws_kms_alias_name" {
   type        = string
 }
 
+variable "aws_kms_replica_alias_name" {
+  default     = "alias/backup-alarms-key-multi-region-replica-test"
+  description = "KMS key name for backup alarms"
+  type        = string
+}
+
 variable "reduced_preprod_backup_retention" {
   description = "AWS Backup variable, if true, pre prod only retains 7 days of backups"
   type        = bool

--- a/test/securityhub-alarms-test/main.tf
+++ b/test/securityhub-alarms-test/main.tf
@@ -2,6 +2,7 @@ module "securityhub-alarms-test" {
   source                                                     = "../../modules/securityhub-alarms"
   securityhub_alarms_kms_name                                = var.securityhub_alarms_kms_name
   securityhub_alarms_multi_region_kms_name                   = var.securityhub_alarms_multi_region_kms_name
+  securityhub_alarms_multi_region_kms_replica_name           = var.securityhub_alarms_multi_region_kms_replica_name
   securityhub_alarms_sns_topic_name                          = var.securityhub_alarms_sns_topic_name
   unauthorised_api_calls_alarm_name                          = var.unauthorised_api_calls_alarm_name
   unauthorised_api_calls_log_metric_filter_name              = var.unauthorised_api_calls_log_metric_filter_name

--- a/test/securityhub-alarms-test/outputs.tf
+++ b/test/securityhub-alarms-test/outputs.tf
@@ -22,6 +22,16 @@ output "securityhub_alarms_multi_region_kms_alias_arn" {
   description = "The ARN of the multi-region KMS alias for SecurityHub alarms"
 }
 
+output "securityhub_alarms_multi_region_kms_key_arn" {
+  value       = module.securityhub-alarms-test.securityhub_alarms_multi_region__replica_kms_key_arn
+  description = "The ARN of the multi-region replica KMS key for SecurityHub alarms"
+}
+
+output "securityhub_alarms_multi_region_kms_alias_arn" {
+  value       = module.securityhub-alarms-test.securityhub_alarms_multi_region_replica_kms_alias_arn
+  description = "The ARN of the multi-region KMS replica alias for SecurityHub alarms"
+}
+
 output "unauthorised_api_calls_metric_filter_id" {
   value       = module.securityhub-alarms-test.unauthorised_api_calls_metric_filter_id
   description = "The ID of the CloudWatch metric filter for unauthorised API calls"

--- a/test/securityhub-alarms-test/outputs.tf
+++ b/test/securityhub-alarms-test/outputs.tf
@@ -22,12 +22,12 @@ output "securityhub_alarms_multi_region_kms_alias_arn" {
   description = "The ARN of the multi-region KMS alias for SecurityHub alarms"
 }
 
-output "securityhub_alarms_multi_region_kms_key_arn" {
+output "securityhub_alarms_multi_region_kms_key_replica_arn" {
   value       = module.securityhub-alarms-test.securityhub_alarms_multi_region__replica_kms_key_arn
   description = "The ARN of the multi-region replica KMS key for SecurityHub alarms"
 }
 
-output "securityhub_alarms_multi_region_kms_alias_arn" {
+output "securityhub_alarms_multi_region_kms_alias_replica_arn" {
   value       = module.securityhub-alarms-test.securityhub_alarms_multi_region_replica_kms_alias_arn
   description = "The ARN of the multi-region KMS replica alias for SecurityHub alarms"
 }

--- a/test/securityhub-alarms-test/variables.tf
+++ b/test/securityhub-alarms-test/variables.tf
@@ -8,6 +8,11 @@ variable "securityhub_alarms_multi_region_kms_name" {
   type    = string
 }
 
+variable "securityhub_alarms_multi_region_kms_replica_name" {
+  default = "alias/securityhub-alarms-key-multi-region-replica"
+  type    = string
+}
+
 variable "securityhub_alarms_sns_topic_name" {
   default = "securityhub-alarms"
   type    = string

--- a/test/securityhub-alarms-test/versions.tf
+++ b/test/securityhub-alarms-test/versions.tf
@@ -11,3 +11,8 @@ terraform {
   }
   required_version = "~> 1.0"
 }
+
+provider "aws" {
+  alias  = "modernisation-platform-eu-west-1"
+  region = "eu-west-1"
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

#7514

## How does this PR fix the problem?

The PR adds the multi region replica keys below and also resources that where using the non multi region keys now use the new ones below

- securityhub-alarms-key-multi-region
- backup-alarms-key-multi-region

## How has this been tested?

Please describe the tests that you ran and provide instructions to reproduce.

Local Terraform Plan

## Deployment Plan / Instructions

Will this deployment impact the platform and / or services on it?

{Please write here}

## Checklist (check `x` in `[ ]` of list items)

- [X] I have performed a self-review of my own code
- [ ] All checks have passed
- [ ] I have made corresponding changes to the documentation
- [ ] Plan and discussed how it should be deployed to PROD (If needed)

## Additional comments (if any)

{Please write here}
