### PR TITLE
Exclude GetMacieSession from SecurityHub Alarm

### DIFF
--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -73,7 +73,7 @@ resource "aws_sns_topic" "securityhub-alarms" {
 # 3.1 - Ensure a log metric filter and alarm exist for unauthorized API calls
 resource "aws_cloudwatch_log_metric_filter" "unauthorised-api-calls" {
   name           = var.unauthorised_api_calls_log_metric_filter_name
-  pattern        = "{($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\" && $.eventName != \"ListDelegatedAdministrators\")}"
+  pattern        = "{($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\" && ($.eventName != \"ListDelegatedAdministrators\") && ($.eventName != \"GetMacieSession\"))}"
   log_group_name = "cloudtrail"
 
   metric_transformation {


### PR DESCRIPTION
When Macie is not enabled on an account, this gives a false positive for unauthorized api calls in the security hub metric.

By excluding this we should see less false alarms.

https://repost.aws/it/questions/QU8ZC1xd9BQV2vnGkod7gQww/macie-not-enabled-means-false-positive-accessdeniedexceptions-in-cloudtrail

Tested filter in cloudwatch core-shared-services
[Old - 2 results including a getmaciesession](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups/log-group/cloudtrail/log-events/$3Fstart$3D2024-10-01T05$253A39$253A00Z$26end$3D2024-10-01T08$253A39$253A28Z$26filterPattern$3D$257B$2528$2524.errorCode+$253D+$2522*UnauthorizedOperation$2522$2529+$257C$257C+$2528$2524.errorCode+$253D+$2522AccessDenied*$2522+$2526$2526+$2528$2524.eventName+$2521$253D+$2522ListDelegatedAdministrators$2522$2529$2529$257D)

[New - 1 result, no getmaciesession](https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups/log-group/cloudtrail/log-events/$3Fstart$3D2024-10-01T05$253A39$253A00Z$26end$3D2024-10-01T08$253A39$253A28Z$26filterPattern$3D$257B$2528$2524.errorCode+$253D+$2522*UnauthorizedOperation$2522$2529+$257C$257C+$2528$2524.errorCode+$253D+$2522AccessDenied*$2522+$2526$2526+$2528$2524.eventName+$2521$253D+$2522ListDelegatedAdministrators$2522$2529+$2526$2526+$2528$2524.eventName+$2521$253D+$2522GetMacieSession$2522$2529$2529$257D)