### PR TITLE
Feature/8076-sec-hub-slack-alerting

### DIFF
--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -94,7 +94,7 @@ resource "aws_cloudwatch_event_rule" "sechub_high_and_critical_findings" {
 
 # When eventbridge rule is triggered send findings to SNS topic
 resource "aws_cloudwatch_event_target" "sechub_findings_sns_topic" {
-  rule      = aws_cloudwatch_event_rule.sechub-high-and-critical-findings.name
+  rule      = aws_cloudwatch_event_rule.sechub_high_and_critical_findings.name
   target_id = "SendToSNS"
   arn       = aws_sns_topic.sechub_findings_sns_topic.arn
 }

--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -66,7 +66,7 @@ resource "aws_securityhub_standards_control" "pci_disable_ensure_mfa_for_root" {
 # SecurityHub Alerting
 
 # Filter for New, High & Critical SecHub findings but exclude Inspector
-resource "aws_cloudwatch_event_rule" "sechub-high-and-critical-findings" {
+resource "aws_cloudwatch_event_rule" "sechub_high_and_critical_findings" {
   name        = "sechub-high-and-critical-findings"
   description = "Check for High or Critical Severity SecHub findings"
   event_pattern = jsonencode({
@@ -175,7 +175,7 @@ resource "aws_kms_alias" "sns_kms_alias" {
 # Static code analysis ignores:
 # - CKV_AWS_109 and CKV_AWS_111: Ignore warnings regarding resource = ["*"]. See https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html
 #   Specifically: "In a key policy, the value of the Resource element is "*", which means "this KMS key." The asterisk ("*") identifies the KMS key to which the key policy is attached."
-data "aws_iam_policy_document" "sns-kms" {
+data "aws_iam_policy_document" "sns_kms" {
   # checkov:skip=CKV_AWS_109: "Key policy requires asterisk resource - see note above"
   # checkov:skip=CKV_AWS_111: "Key policy requires asterisk resource - see note above"
   # checkov:skip=CKV_AWS_356: "Key policy requires asterisk resource - see note above"

--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -62,3 +62,32 @@ resource "aws_securityhub_standards_control" "pci_disable_ensure_mfa_for_root" {
   disabled_reason       = "Root login actions prevented with SCPs"
   depends_on            = [aws_securityhub_standards_subscription.pci]
 }
+
+# SecurityHub Alerting
+
+# Filter for New, High & Critical SecHub findings but exclude Inspector
+resource "aws_cloudwatch_event_rule" "sechub-high-and-critical-findings" {
+  name        = "sechub-high-and-critical-findings"
+  description = "Check for High or Critical Severity SecHub findings"
+  event_pattern = jsonencode({
+    "source" : ["aws.securityhub"],
+    "detail-type" : ["Security Hub Findings - Imported"],
+    "detail" : {
+      "findings" : {
+        "Severity" : {
+          "Label" : ["HIGH", "CRITICAL"]
+        },
+        "Workflow" : {
+          "Status" : ["NEW"]
+        },
+        "ProductFields" : {
+          "aws/securityhub/ProductName" : [
+            {
+              "anything-but" : "Inspector"
+            }
+          ]
+        }
+      }
+    }
+  })
+}

--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -94,7 +94,7 @@ resource "aws_cloudwatch_event_rule" "sechub-high-and-critical-findings" {
 
 # When eventbridge rule is triggered send findings to SNS topic
 resource "aws_cloudwatch_event_target" "sechub_findings_sns_topic" {
-  rule      = aws_cloudwatch_event_rule.sechub_findings-event-rule.name
+  rule      = aws_cloudwatch_event_rule.sechub-high-and-critical-findings.name
   target_id = "SendToSNS"
   arn       = aws_sns_topic.sechub_findings_sns_topic.arn
 }

--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -164,7 +164,7 @@ data "aws_iam_policy_document" "sechub_findings_sns_topic_policy" {
 resource "aws_kms_key" "sns_kms_key" {
   description         = "KMS key for SNS topic encryption"
   enable_key_rotation = true
-  policy              = data.aws_iam_policy_document.sns-kms.json
+  policy              = data.aws_iam_policy_document.sns_kms.json
 }
 
 resource "aws_kms_alias" "sns_kms_alias" {


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/8076

## How does this PR fix the problem?

This is the first PR of multiple I intend to raise for this story. 

This first one adds an eventbridge rule which looks for `HIGH` & `CRITICAL` findings with a worklfow status of `NEW` and also ignores Inspector related findings as these have been deemed out of scope for us as the platform team.

I've also created a new encrypted sns topic to be triggered when the eventbridge rule receives a new finding.

I will add unit tests for this in another PR and will then also look at how this hooks in with pagerduty/slack.

## How has this been tested?

I've tested it by deploying in sprinkler locally and subscribing to the sns topic manually via email. I have been receiving emails via this for sprinkler so am confident it is working as desired.