### PR TITLE
Enable PagerDuty/Slack alerts for Security Hub findings

### DIFF
--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -219,3 +219,13 @@ data "aws_iam_policy_document" "sns_kms" {
     }
   }
 }
+
+# Setup PagerDuty Alerting in all enabled regions
+module "pagerduty_alerts_securityhub" {
+  depends_on = [
+    aws_sns_topic.sechub_findings_sns_topic
+  ]
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
+  sns_topics                = [aws_sns_topic.sechub_findings_sns_topic.name]
+  pagerduty_integration_key = var.pagerduty_integration_key
+}

--- a/modules/securityhub/variables.tf
+++ b/modules/securityhub/variables.tf
@@ -15,3 +15,9 @@ variable "sechub_sns_kms_key_name" {
   default     = "alias/sns-kms-key"
   type        = string
 }
+
+variable "pagerduty_integration_key" {
+  default     = ""
+  description = "A PagerDuty integration key to pass into a PagerDuty integration"
+  type        = string
+}

--- a/securityhub.tf
+++ b/securityhub.tf
@@ -5,6 +5,7 @@ module "securityhub-ap-northeast-1" {
   providers = {
     aws = aws.ap-northeast-1
   }
+  pagerduty_integration_key = var.pagerduty_integration_key
 }
 
 module "securityhub-ap-northeast-2" {
@@ -14,6 +15,7 @@ module "securityhub-ap-northeast-2" {
   providers = {
     aws = aws.ap-northeast-2
   }
+  pagerduty_integration_key = var.pagerduty_integration_key
 }
 
 module "securityhub-ap-south-1" {
@@ -23,6 +25,7 @@ module "securityhub-ap-south-1" {
   providers = {
     aws = aws.ap-south-1
   }
+  pagerduty_integration_key = var.pagerduty_integration_key
 }
 
 module "securityhub-ap-southeast-1" {
@@ -32,6 +35,7 @@ module "securityhub-ap-southeast-1" {
   providers = {
     aws = aws.ap-southeast-1
   }
+  pagerduty_integration_key = var.pagerduty_integration_key
 }
 
 module "securityhub-ap-southeast-2" {
@@ -41,6 +45,7 @@ module "securityhub-ap-southeast-2" {
   providers = {
     aws = aws.ap-southeast-2
   }
+  pagerduty_integration_key = var.pagerduty_integration_key
 }
 
 module "securityhub-ca-central-1" {
@@ -50,6 +55,7 @@ module "securityhub-ca-central-1" {
   providers = {
     aws = aws.ca-central-1
   }
+  pagerduty_integration_key = var.pagerduty_integration_key
 }
 
 module "securityhub-eu-central-1" {
@@ -59,6 +65,7 @@ module "securityhub-eu-central-1" {
   providers = {
     aws = aws.eu-central-1
   }
+  pagerduty_integration_key = var.pagerduty_integration_key
 }
 
 module "securityhub-eu-north-1" {
@@ -68,6 +75,7 @@ module "securityhub-eu-north-1" {
   providers = {
     aws = aws.eu-north-1
   }
+  pagerduty_integration_key = var.pagerduty_integration_key
 }
 
 module "securityhub-eu-west-1" {
@@ -77,6 +85,7 @@ module "securityhub-eu-west-1" {
   providers = {
     aws = aws.eu-west-1
   }
+  pagerduty_integration_key = var.pagerduty_integration_key
 }
 
 module "securityhub-eu-west-2" {
@@ -86,6 +95,7 @@ module "securityhub-eu-west-2" {
   providers = {
     aws = aws.eu-west-2
   }
+  pagerduty_integration_key = var.pagerduty_integration_key
 }
 
 module "securityhub-eu-west-3" {
@@ -95,6 +105,7 @@ module "securityhub-eu-west-3" {
   providers = {
     aws = aws.eu-west-3
   }
+  pagerduty_integration_key = var.pagerduty_integration_key
 }
 
 module "securityhub-sa-east-1" {
@@ -104,6 +115,7 @@ module "securityhub-sa-east-1" {
   providers = {
     aws = aws.sa-east-1
   }
+  pagerduty_integration_key = var.pagerduty_integration_key
 }
 
 module "securityhub-us-east-1" {
@@ -113,6 +125,7 @@ module "securityhub-us-east-1" {
   providers = {
     aws = aws.us-east-1
   }
+  pagerduty_integration_key = var.pagerduty_integration_key
 }
 
 module "securityhub-us-east-2" {
@@ -122,6 +135,7 @@ module "securityhub-us-east-2" {
   providers = {
     aws = aws.us-east-2
   }
+  pagerduty_integration_key = var.pagerduty_integration_key
 }
 
 module "securityhub-us-west-1" {
@@ -131,6 +145,7 @@ module "securityhub-us-west-1" {
   providers = {
     aws = aws.us-west-1
   }
+  pagerduty_integration_key = var.pagerduty_integration_key
 }
 
 module "securityhub-us-west-2" {
@@ -140,4 +155,5 @@ module "securityhub-us-west-2" {
   providers = {
     aws = aws.us-west-2
   }
+  pagerduty_integration_key = var.pagerduty_integration_key
 }

--- a/variables.tf
+++ b/variables.tf
@@ -66,3 +66,9 @@ variable "reduced_preprod_backup_retention" {
   description = "AWS Backup variable, if true, pre prod only retains 7 days of backups"
   type        = bool
 }
+
+variable "pagerduty_integration_key" {
+  default     = ""
+  description = "A PagerDuty integration key to pass into a PagerDuty integration"
+  type        = string
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/8076

## How does this PR fix the problem?

This PR enables the PagerDuty integration so that the SNS topic linked to the EventBridge rule for Security Hub findings will be subscribed to PagerDuty. 

When new findings are raised it will create low priority incidents in the [Security Hub Alerts](https://moj-digital-tools.pagerduty.com/service-directory/PN4O28R) service and that will in turn send alerts to the [modernisation-platform-security-hub-alerts](https://moj.enterprise.slack.com/archives/C07SNBJBVC6) slack channel.  

The pagerduty integration key has been added as an input and will be fed in when I reference the module  in the baselines MP code.

## How has this been tested?

I've tested it by deploying in sprinkler locally.