### PR TITLE
Rename KMS key for sechub

### DIFF
--- a/modules/securityhub/variables.tf
+++ b/modules/securityhub/variables.tf
@@ -12,7 +12,7 @@ variable "sechub_sns_topic_name" {
 
 variable "sechub_sns_kms_key_name" {
   description = "SecurityHub SNS Topic KMS key name"
-  default     = "alias/sns-kms-key"
+  default     = "alias/sechub-sns-kms-key"
   type        = string
 }
 

--- a/test/baselines_test.go
+++ b/test/baselines_test.go
@@ -345,7 +345,7 @@ func TestTerraformSecurityHub(t *testing.T) {
 	// Unique names for SecurityHub resources
 	SecHubEventbridgeRuleName := fmt.Sprintf("sechub_high_and_critical_findings-%s", uniqueId)
 	SecHubSNSTopicName := fmt.Sprintf("sechub_findings_sns_topic-%s", uniqueId)
-	SecHubSNSTopicKMSKey := fmt.Sprintf("alias/sns-kms-key-%s", uniqueId)
+	SecHubSNSTopicKMSKey := fmt.Sprintf("alias/sechub-sns-kms-key-%s", uniqueId)
 
 	terraformOptions := &terraform.Options{
 		TerraformDir: terraformDir,

--- a/test/securityhub-test/variables.tf
+++ b/test/securityhub-test/variables.tf
@@ -12,6 +12,6 @@ variable "sechub_sns_topic_name" {
 
 variable "sechub_sns_kms_key_name" {
   description = "SecurityHub SNS Topic KMS key name"
-  default     = "alias/sns-kms-key"
+  default     = "alias/sechub-sns-kms-key"
   type        = string
 }


### PR DESCRIPTION
## A reference to the issue / Description of it

https://github.com/ministryofjustice/modernisation-platform/issues/8076

When rolling out `v7.9.0` of the baseline I noticed a clash in the naming of KMS key in the `core-network-services` account.

## How does this PR fix the problem?

I've updated the alias to include `sechub` so that it's unique and won't clash.

## How has this been tested?

I've tested it by deploying in sprinkler locally.