### PR TITLE
Revert "Rename KMS key for sechub"

### DIFF
--- a/modules/securityhub/variables.tf
+++ b/modules/securityhub/variables.tf
@@ -12,7 +12,7 @@ variable "sechub_sns_topic_name" {
 
 variable "sechub_sns_kms_key_name" {
   description = "SecurityHub SNS Topic KMS key name"
-  default     = "alias/sechub-sns-kms-key"
+  default     = "alias/sns-kms-key"
   type        = string
 }
 

--- a/test/baselines_test.go
+++ b/test/baselines_test.go
@@ -345,7 +345,7 @@ func TestTerraformSecurityHub(t *testing.T) {
 	// Unique names for SecurityHub resources
 	SecHubEventbridgeRuleName := fmt.Sprintf("sechub_high_and_critical_findings-%s", uniqueId)
 	SecHubSNSTopicName := fmt.Sprintf("sechub_findings_sns_topic-%s", uniqueId)
-	SecHubSNSTopicKMSKey := fmt.Sprintf("alias/sechub-sns-kms-key-%s", uniqueId)
+	SecHubSNSTopicKMSKey := fmt.Sprintf("alias/sns-kms-key-%s", uniqueId)
 
 	terraformOptions := &terraform.Options{
 		TerraformDir: terraformDir,

--- a/test/securityhub-test/variables.tf
+++ b/test/securityhub-test/variables.tf
@@ -12,6 +12,6 @@ variable "sechub_sns_topic_name" {
 
 variable "sechub_sns_kms_key_name" {
   description = "SecurityHub SNS Topic KMS key name"
-  default     = "alias/sechub-sns-kms-key"
+  default     = "alias/sns-kms-key"
   type        = string
 }


### PR DESCRIPTION
Reverts ministryofjustice/modernisation-platform-terraform-baselines#635
I'm going to try using `name_prefix` instead as it will add a unique ID to the name.