### PR TITLE
Conditionally create SecurityHub alerting resources

### DIFF
--- a/modules/securityhub/variables.tf
+++ b/modules/securityhub/variables.tf
@@ -1,3 +1,9 @@
+variable "sechub_alerting_region" {
+  default     = "eu-west-2"
+  description = "The AWS region where securityhub alerting resources are selectively created"
+  type        = string
+}
+
 variable "sechub_eventbridge_rule_name" {
   description = "SecurityHub Eventbridge rule name"
   default     = "sechub_high_and_critical_findings"

--- a/securityhub.tf
+++ b/securityhub.tf
@@ -95,6 +95,7 @@ module "securityhub-eu-west-2" {
   providers = {
     aws = aws.eu-west-2
   }
+  sechub_alerting_region    = var.sechub_alerting_region
   pagerduty_integration_key = var.pagerduty_integration_key
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -72,3 +72,9 @@ variable "pagerduty_integration_key" {
   description = "A PagerDuty integration key to pass into a PagerDuty integration"
   type        = string
 }
+
+variable "sechub_alerting_region" {
+  default     = "eu-west-2"
+  description = "The AWS region where securityhub alerting resources are selectively created"
+  type        = string
+}


### PR DESCRIPTION
This PR updates the securityhub module to ensure that certain resources, including CloudWatch Event Rules, SNS Topics, and KMS keys, are only created in the `eu-west-2` region. The conditional creation is controlled by adding a `sechub_alerting_region` variable to the module and using count attributes for resources that should only exist in `eu-west-2`.