### PR TITLE
conditionally create SecurityHub alerting resources

### DIFF
--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -67,6 +67,7 @@ resource "aws_securityhub_standards_control" "pci_disable_ensure_mfa_for_root" {
 
 # Filter for New, High & Critical SecHub findings but exclude Inspector
 resource "aws_cloudwatch_event_rule" "sechub_high_and_critical_findings" {
+  count       = var.enable_securityhub_alerts ? 1 : 0
   name        = var.sechub_eventbridge_rule_name
   description = "Check for High or Critical Severity SecHub findings"
   event_pattern = jsonencode({
@@ -75,7 +76,7 @@ resource "aws_cloudwatch_event_rule" "sechub_high_and_critical_findings" {
     "detail" : {
       "findings" : {
         "Severity" : {
-          "Label" : ["HIGH", "CRITICAL"]
+          "Label" : ["CRITICAL"]
         },
         "Workflow" : {
           "Status" : ["NEW"]
@@ -94,22 +95,26 @@ resource "aws_cloudwatch_event_rule" "sechub_high_and_critical_findings" {
 
 # When eventbridge rule is triggered send findings to SNS topic
 resource "aws_cloudwatch_event_target" "sechub_findings_sns_topic" {
-  rule      = aws_cloudwatch_event_rule.sechub_high_and_critical_findings.name
+  count     = var.enable_securityhub_alerts ? 1 : 0
+  rule      = aws_cloudwatch_event_rule.sechub_high_and_critical_findings[0].name
   target_id = "SendToSNS"
-  arn       = aws_sns_topic.sechub_findings_sns_topic.arn
+  arn       = aws_sns_topic.sechub_findings_sns_topic[0].arn
 }
 
 # Create SNS topic and access policy
 resource "aws_sns_topic" "sechub_findings_sns_topic" {
+  count             = var.enable_securityhub_alerts ? 1 : 0
   name              = var.sechub_sns_topic_name
-  kms_master_key_id = aws_kms_key.sns_kms_key.id
+  kms_master_key_id = length(aws_kms_key.sns_kms_key) > 0 ? aws_kms_key.sns_kms_key[0].id : null
 }
 resource "aws_sns_topic_policy" "sechub_findings_sns_topic" {
-  arn    = aws_sns_topic.sechub_findings_sns_topic.arn
-  policy = data.aws_iam_policy_document.sechub_findings_sns_topic_policy.json
+  count  = var.enable_securityhub_alerts ? 1 : 0
+  arn    = aws_sns_topic.sechub_findings_sns_topic[0].arn
+  policy = data.aws_iam_policy_document.sechub_findings_sns_topic_policy[0].json
 }
 
 data "aws_iam_policy_document" "sechub_findings_sns_topic_policy" {
+  count     = length(aws_sns_topic.sechub_findings_sns_topic) > 0 ? 1 : 0
   policy_id = "sechub findings sns topic policy"
 
   statement {
@@ -126,7 +131,7 @@ data "aws_iam_policy_document" "sechub_findings_sns_topic_policy" {
       "sns:Subscribe"
     ]
     resources = [
-      aws_sns_topic.sechub_findings_sns_topic.arn,
+      aws_sns_topic.sechub_findings_sns_topic[0].arn
     ]
     condition {
       test     = "StringEquals"
@@ -149,7 +154,7 @@ data "aws_iam_policy_document" "sechub_findings_sns_topic_policy" {
       "sns:Publish",
     ]
     resources = [
-      aws_sns_topic.sechub_findings_sns_topic.arn,
+      aws_sns_topic.sechub_findings_sns_topic[0].arn
     ]
     principals {
       type = "Service"
@@ -162,14 +167,16 @@ data "aws_iam_policy_document" "sechub_findings_sns_topic_policy" {
 
 # Create CMK to encrypt SNS topic
 resource "aws_kms_key" "sns_kms_key" {
+  count               = var.enable_securityhub_alerts ? 1 : 0
   description         = "KMS key for SNS topic encryption"
   enable_key_rotation = true
   policy              = data.aws_iam_policy_document.sns_kms.json
 }
 
 resource "aws_kms_alias" "sns_kms_alias" {
+  count         = var.enable_securityhub_alerts ? 1 : 0
   name_prefix   = var.sechub_sns_kms_key_name
-  target_key_id = aws_kms_key.sns_kms_key.id
+  target_key_id = aws_kms_key.sns_kms_key[0].id
 }
 
 # Static code analysis ignores:
@@ -220,12 +227,13 @@ data "aws_iam_policy_document" "sns_kms" {
   }
 }
 
-# Setup PagerDuty Alerting in all enabled regions
+# Setup PagerDuty Alerting in eu-west-2 region
 module "pagerduty_alerts_securityhub" {
+  count = var.enable_securityhub_alerts ? 1 : 0
   depends_on = [
     aws_sns_topic.sechub_findings_sns_topic
   ]
   source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
-  sns_topics                = [aws_sns_topic.sechub_findings_sns_topic.name]
+  sns_topics                = [aws_sns_topic.sechub_findings_sns_topic[0].name]
   pagerduty_integration_key = var.pagerduty_integration_key
 }

--- a/modules/securityhub/outputs.tf
+++ b/modules/securityhub/outputs.tf
@@ -1,13 +1,14 @@
 output "sechub_eventbridge_rule_arn" {
   description = "The ARN of the SecurityHub EventBridge rule"
-  value       = aws_cloudwatch_event_rule.sechub_high_and_critical_findings.arn
+  value       = length(aws_cloudwatch_event_rule.sechub_high_and_critical_findings) > 0 ? aws_cloudwatch_event_rule.sechub_high_and_critical_findings[0].arn : null
 }
+
 output "sechub_sns_topic_arn" {
   description = "The ARN of the SecurityHub SNS topic"
-  value       = aws_sns_topic.sechub_findings_sns_topic.arn
+  value       = length(aws_sns_topic.sechub_findings_sns_topic) > 0 ? aws_sns_topic.sechub_findings_sns_topic[0].arn : null
 }
 
 output "sechub_sns_kms_key_arn" {
   description = "The ARN of the SecurityHub SNS Topic KMS key"
-  value       = aws_kms_key.sns_kms_key.arn
+  value       = length(aws_kms_key.sns_kms_key) > 0 ? aws_kms_key.sns_kms_key[0].arn : null
 }

--- a/modules/securityhub/variables.tf
+++ b/modules/securityhub/variables.tf
@@ -1,3 +1,9 @@
+variable "enable_securityhub_alerts" {
+  default     = false
+  description = "Flag to indicate if alerting resources should be created in the region"
+  type        = bool
+}
+
 variable "sechub_eventbridge_rule_name" {
   description = "SecurityHub Eventbridge rule name"
   default     = "sechub_high_and_critical_findings"

--- a/securityhub.tf
+++ b/securityhub.tf
@@ -95,6 +95,7 @@ module "securityhub-eu-west-2" {
   providers = {
     aws = aws.eu-west-2
   }
+  enable_securityhub_alerts = var.enable_securityhub_alerts
   pagerduty_integration_key = var.pagerduty_integration_key
 }
 

--- a/test/baselines_test.go
+++ b/test/baselines_test.go
@@ -363,6 +363,7 @@ func TestTerraformSecurityHub(t *testing.T) {
 			"sechub_eventbridge_rule_name": SecHubEventbridgeRuleName,
 			"sechub_sns_topic_name":        SecHubSNSTopicName,
 			"sechub_sns_kms_key_name":      SecHubSNSTopicKMSKey,
+			"enable_securityhub_alerts":	true,
 		},
 	}
 	// Clean up resources with "terraform destroy" at the end of the test

--- a/test/securityhub-test/main.tf
+++ b/test/securityhub-test/main.tf
@@ -3,4 +3,5 @@ module "securityhub-test" {
   sechub_eventbridge_rule_name = var.sechub_eventbridge_rule_name
   sechub_sns_topic_name        = var.sechub_sns_topic_name
   sechub_sns_kms_key_name      = var.sechub_sns_kms_key_name
+  enable_securityhub_alerts    = var.enable_securityhub_alerts
 }

--- a/test/securityhub-test/variables.tf
+++ b/test/securityhub-test/variables.tf
@@ -15,3 +15,9 @@ variable "sechub_sns_kms_key_name" {
   default     = "alias/sns-kms-key"
   type        = string
 }
+
+variable "enable_securityhub_alerts" {
+  default     = false
+  description = "Flag to indicate if alerting resources should be created in the region"
+  type        = bool
+}

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,12 @@ variable "enabled_imdsv2_regions" {
   type        = list(string)
 }
 
+variable "enable_securityhub_alerts" {
+  default     = false
+  description = "Flag to indicate if alerting resources should be created in the region"
+  type        = bool
+}
+
 variable "reduced_preprod_backup_retention" {
   description = "AWS Backup variable, if true, pre prod only retains 7 days of backups"
   type        = bool


### PR DESCRIPTION
This PR updates the securityhub module to ensure that certain resources, including CloudWatch Event Rules, SNS Topics, and KMS keys, are only created in the `eu-west-2` region. The conditional creation is controlled by adding a `sechub_alerting_region` variable to the module and using count attributes for resources that should only exist in `eu-west-2`.