### PR TITLE
Align backup module approach to notifications

### DIFF
--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -58,8 +58,6 @@ data "aws_iam_policy_document" "backup-alarms-kms" {
 
 # Define the SNS topic, conditionally created if the region is eu-west-2 and is production
 resource "aws_sns_topic" "backup_vault_topic" {
-  #checkov:skip=CKV_AWS_26:"topic is encrypted, but doesn't like the local reference"  
-  count             = (local.is_production && data.aws_region.current.name == "eu-west-2") ? 1 : 0
   kms_master_key_id = aws_kms_key.backup_alarms_multi_region.id
   name              = var.backup_vault_lock_sns_topic_name
   tags = merge(var.tags, {
@@ -189,20 +187,16 @@ resource "aws_backup_selection" "non_production" {
 # SNS topic
 # trivy:ignore:avd-aws-0136
 resource "aws_sns_topic" "backup_failure_topic" {
-  count = (local.is_production && data.aws_region.current.name == "eu-west-2") ? 1 : 0
-  #checkov:skip=CKV_AWS_26:"topic is encrypted, but doesn't like the local reference"
   kms_master_key_id = aws_kms_key.backup_alarms_multi_region.id
   name              = var.backup_aws_sns_topic_name
   tags = merge(var.tags, {
-    Description = "This backup topic is so the MP team can subscribe to backup notifications from selected accounts and teams using member-unrestricted accounts can create their own subscriptions"
+    Description = "Allows customers to subscribe to backup notifications for notification on failed jobs"
   })
 }
 
 # Attaches the SNS topic to the backup vault to subscribe for notifications
 resource "aws_backup_vault_notifications" "aws_backup_vault_notifications" {
-  count               = (local.is_production && data.aws_region.current.name == "eu-west-2") ? 1 : 0
   backup_vault_events = ["BACKUP_JOB_FAILED"]
   backup_vault_name   = aws_backup_vault.default.name
-  sns_topic_arn       = aws_sns_topic.backup_failure_topic[0].arn
+  sns_topic_arn       = aws_sns_topic.backup_failure_topic.arn
 }
-

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -55,8 +55,6 @@ data "aws_iam_policy_document" "backup-alarms-kms" {
   }
 }
 
-
-# Define the SNS topic, conditionally created if the region is eu-west-2 and is production
 resource "aws_sns_topic" "backup_vault_topic" {
   kms_master_key_id = aws_kms_key.backup_alarms_multi_region.id
   name              = var.backup_vault_lock_sns_topic_name

--- a/modules/backup/outputs.tf
+++ b/modules/backup/outputs.tf
@@ -18,14 +18,14 @@ output "aws_backup_selection_non_production" {
   value = aws_backup_selection.non_production.id
 }
 output "backup_aws_sns_topic_arn" {
-  value = length(aws_sns_topic.backup_failure_topic) > 0 ? aws_sns_topic.backup_failure_topic[0].arn : ""
+  value = aws_sns_topic.backup_failure_topic.arn
 }
 
 output "aws_backup_plan_non_production_rule" {
   value = aws_backup_plan.non_production.rule
 }
 
-output "backup_vault_lock_sns_topic_name" {
-  value = length(aws_sns_topic.backup_vault_topic) > 0 ? aws_sns_topic.backup_vault_topic[0].arn : ""
+output "backup_vault_lock_sns_topic_arn" {
+  value = aws_sns_topic.backup_vault_topic.arn
 }
 

--- a/test/backup-test/outputs.tf
+++ b/test/backup-test/outputs.tf
@@ -26,6 +26,6 @@ output "aws_backup_plan_non_production_rule" {
   value = module.backup-test.aws_backup_plan_non_production_rule
 }
 
-output "backup_vault_lock_sns_topic_name" {
-  value = module.backup-test.backup_vault_lock_sns_topic_name
+output "backup_vault_lock_sns_topic_arn" {
+  value = module.backup-test.backup_vault_lock_sns_topic_arn
 }

--- a/test/baselines_test.go
+++ b/test/baselines_test.go
@@ -26,7 +26,7 @@ func TestTerraformBackup(t *testing.T) {
 	NonProdBackupPlanName := fmt.Sprintf("backup-daily-cold-storage-monthly-retain-30-days-%s", uniqueId)
 	NonProdBackupSelectionName := fmt.Sprintf("non-production-backup-%s", uniqueId)
 	BackupSNSTopicName := fmt.Sprintf("backup_failure_topic-%s", uniqueId)
-	BackupLockSNSTopicName := fmt.Sprintf("backup_vault_lock_sns_topic_name-%s", uniqueId)
+	BackupLockSNSTopicName := fmt.Sprintf("backup_vault_lock_sns_topic-%s", uniqueId)
 
 	terraformOptions := &terraform.Options{
 		TerraformDir: terraformDir,

--- a/test/baselines_test.go
+++ b/test/baselines_test.go
@@ -26,7 +26,7 @@ func TestTerraformBackup(t *testing.T) {
 	NonProdBackupPlanName := fmt.Sprintf("backup-daily-cold-storage-monthly-retain-30-days-%s", uniqueId)
 	NonProdBackupSelectionName := fmt.Sprintf("non-production-backup-%s", uniqueId)
 	BackupSNSTopicName := fmt.Sprintf("backup_failure_topic-%s", uniqueId)
-	BackupLockSNSTopicName := fmt.Sprintf("backup_vault_lock_sns_topic-%s", uniqueId)
+	BackupLockSNSTopicName := fmt.Sprintf("backup_vault_lock_sns_topic_name-%s", uniqueId)
 
 	terraformOptions := &terraform.Options{
 		TerraformDir: terraformDir,
@@ -37,8 +37,8 @@ func TestTerraformBackup(t *testing.T) {
 			"production_backup_selection_name":     ProdBackupSelectionName,
 			"non_production_backup_plan_name":      NonProdBackupPlanName,
 			"non_production_backup_selection_name": NonProdBackupSelectionName,
-			"backup_aws_sns_topic_name":            BackupSNSTopicName,
-			"backup_vault_lock_sns_topic_name":     BackupLockSNSTopicName,
+			"backup_aws_sns_topic_name":             BackupSNSTopicName,
+			"backup_vault_lock_sns_topic_name":      BackupLockSNSTopicName,
 		},
 	}
 	// Clean up resources with "terraform destroy" at the end of the test
@@ -58,7 +58,7 @@ func TestTerraformBackup(t *testing.T) {
 	AwsBackupSelectionNonProd := terraform.Output(t, terraformOptions, "aws_backup_selection_non_production")
 	AwsBackupSNSTopicArn := terraform.Output(t, terraformOptions, "backup_aws_sns_topic_arn")
 	AwsNonProdBackupRetentionDays := terraform.Output(t, terraformOptions, "aws_backup_plan_non_production_rule")
-	AwsVaultSNSTopicName := terraform.Output(t, terraformOptions, "backup_vault_lock_sns_topic_name")
+	AwsVaultSNSTopicArn := terraform.Output(t, terraformOptions, "backup_vault_lock_sns_topic_arn")
 
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:backup:eu-west-2:[0-9]{12}:backup-vault:everything-`+uniqueId), AwsBackupVaultArn)
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:backup:eu-west-2:[0-9]{12}:backup-plan:*`), AwsBackupPlanProd)
@@ -67,7 +67,7 @@ func TestTerraformBackup(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile(`^*`), AwsBackupSelectionNonProd)
 	assert.Regexp(t, regexp.MustCompile(`^arn:aws:sns:eu-west-2:[0-9]{12}:backup_failure_topic-`+uniqueId), AwsBackupSNSTopicArn)
 	assert.Regexp(t, regexp.MustCompile(`delete_after:40`), AwsNonProdBackupRetentionDays)
-	assert.Regexp(t, regexp.MustCompile(`^arn:aws:sns:eu-west-2:[0-9]{12}:backup_vault_lock_sns_topic_name-`+uniqueId), AwsVaultSNSTopicName)
+	assert.Regexp(t, regexp.MustCompile(`^arn:aws:sns:eu-west-2:[0-9]{12}:backup_vault_lock_sns_topic_name-`+uniqueId), AwsVaultSNSTopicArn)
 
 }
 


### PR DESCRIPTION
Our `backup` module presently uses conditional handling so that only production accounts in eu-west-2 publish failure notifications to an SNS topic.

This is not in keeping with the consistent approach across our other baseline modules. Given the low volume of expected messages and the negligible impact on cost, maintaining consistency here would be more appropriate than introducing special handling.