### PR TITLE
Issue/8961

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ module "ebs-encryption" {
 |              Name               |                                Description                                |  Type  | Default | Required |
 | :-----------------------------: | :-----------------------------------------------------------------------: | :----: | :-----: | -------- |
 |         root_account_id         | The AWS Organisations root account ID that this account should be part of | string |         | yes      |
+|         current_acount_id       | The ID for the account into which the module is being deployed            | string |         | yes
 |              tags               |               Tags to apply to resources, where applicable                |  map   |   {}    | no       |
 | enabled_access_analyzer_regions |                 Regions to enable IAM Access Analyzer in                  |  list  |   []    | no       |
 |     enabled_backup_regions      |                      Regions to enable AWS Backup in                      |  list  |   []    | no       |

--- a/config.tf
+++ b/config.tf
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "config-s3-policy" {
   version = "2012-10-17"
 
   statement {
-    sid = "AWSConfigBucketPermissionsCheck"
+    sid    = "AWSConfigBucketPermissionsCheck"
     effect = "Allow"
     actions = [
       "s3:GetBucketAcl"
@@ -84,7 +84,7 @@ data "aws_iam_policy_document" "config-s3-policy" {
   }
 
   statement {
-    sid = "AWSConfigBucketExistenceCheck"
+    sid    = "AWSConfigBucketExistenceCheck"
     effect = "Allow"
     actions = [
       "s3:ListBucket"
@@ -105,9 +105,9 @@ data "aws_iam_policy_document" "config-s3-policy" {
   }
 
   statement {
-    sid = "AWSConfigBucketDelivery"
-    effect    = "Allow"
-    actions   = [
+    sid    = "AWSConfigBucketDelivery"
+    effect = "Allow"
+    actions = [
       "s3:PutObject"
     ]
     resources = ["${module.config-bucket.bucket.arn}/*"]
@@ -131,9 +131,9 @@ data "aws_iam_policy_document" "config-s3-policy" {
 # KMS Key & Policy for the SNS Topic. This is required for the user of a service-linked role.
 
 resource "aws_kms_key" "config-sns-key" {
-  description             = "KMS key for AWS Config SNS topic"
-  multi_region            = true
-  policy = data.aws_iam_policy_document.config-sns-key-policy.json
+  description  = "KMS key for AWS Config SNS topic"
+  multi_region = true
+  policy       = data.aws_iam_policy_document.config-sns-key-policy.json
 }
 
 resource "aws_kms_alias" "config-sns-key-alias" {
@@ -164,9 +164,9 @@ data "aws_iam_policy_document" "config-sns-key-policy" {
   }
 
   statement {
-    sid     = "AWSConfigSNSPolicy"
-    effect  = "Allow"
-    actions = ["kms:Decrypt", "kms:GenerateDataKey"]
+    sid       = "AWSConfigSNSPolicy"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt", "kms:GenerateDataKey"]
     resources = ["*"]
     principals {
       type        = "Service"
@@ -191,12 +191,12 @@ module "config-ap-northeast-1" {
   providers = {
     aws = aws.ap-northeast-1
   }
-  iam_role_arn    = aws_iam_service_linked_role.config.arn
-  s3_bucket_id    = module.config-bucket.bucket.id
-  root_account_id = var.root_account_id
-  home_region     = data.aws_region.current.name
+  iam_role_arn       = aws_iam_service_linked_role.config.arn
+  s3_bucket_id       = module.config-bucket.bucket.id
+  root_account_id    = var.root_account_id
+  home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
-  sns_topic_key = aws_kms_key.config-sns-key.key_id
+  sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -212,12 +212,12 @@ module "config-ap-northeast-2" {
   providers = {
     aws = aws.ap-northeast-2
   }
-  iam_role_arn    = aws_iam_service_linked_role.config.arn
-  s3_bucket_id    = module.config-bucket.bucket.id
-  root_account_id = var.root_account_id
-  home_region     = data.aws_region.current.name
+  iam_role_arn       = aws_iam_service_linked_role.config.arn
+  s3_bucket_id       = module.config-bucket.bucket.id
+  root_account_id    = var.root_account_id
+  home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
-  sns_topic_key = aws_kms_key.config-sns-key.key_id
+  sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -233,12 +233,12 @@ module "config-ap-south-1" {
   providers = {
     aws = aws.ap-south-1
   }
-  iam_role_arn    = aws_iam_service_linked_role.config.arn
-  s3_bucket_id    = module.config-bucket.bucket.id
-  root_account_id = var.root_account_id
-  home_region     = data.aws_region.current.name
+  iam_role_arn       = aws_iam_service_linked_role.config.arn
+  s3_bucket_id       = module.config-bucket.bucket.id
+  root_account_id    = var.root_account_id
+  home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
-  sns_topic_key = aws_kms_key.config-sns-key.key_id
+  sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -254,12 +254,12 @@ module "config-ap-southeast-1" {
   providers = {
     aws = aws.ap-southeast-1
   }
-  iam_role_arn    = aws_iam_service_linked_role.config.arn
-  s3_bucket_id    = module.config-bucket.bucket.id
-  root_account_id = var.root_account_id
-  home_region     = data.aws_region.current.name
+  iam_role_arn       = aws_iam_service_linked_role.config.arn
+  s3_bucket_id       = module.config-bucket.bucket.id
+  root_account_id    = var.root_account_id
+  home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
-  sns_topic_key = aws_kms_key.config-sns-key.key_id
+  sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -275,12 +275,12 @@ module "config-ap-southeast-2" {
   providers = {
     aws = aws.ap-southeast-2
   }
-  iam_role_arn    = aws_iam_service_linked_role.config.arn
-  s3_bucket_id    = module.config-bucket.bucket.id
-  root_account_id = var.root_account_id
-  home_region     = data.aws_region.current.name
+  iam_role_arn       = aws_iam_service_linked_role.config.arn
+  s3_bucket_id       = module.config-bucket.bucket.id
+  root_account_id    = var.root_account_id
+  home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
-  sns_topic_key = aws_kms_key.config-sns-key.key_id
+  sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -296,12 +296,12 @@ module "config-ca-central-1" {
   providers = {
     aws = aws.ca-central-1
   }
-  iam_role_arn    = aws_iam_service_linked_role.config.arn
-  s3_bucket_id    = module.config-bucket.bucket.id
-  root_account_id = var.root_account_id
-  home_region     = data.aws_region.current.name
-  current_account_id = var.current_account_id  
-  sns_topic_key = aws_kms_key.config-sns-key.key_id
+  iam_role_arn       = aws_iam_service_linked_role.config.arn
+  s3_bucket_id       = module.config-bucket.bucket.id
+  root_account_id    = var.root_account_id
+  home_region        = data.aws_region.current.name
+  current_account_id = var.current_account_id
+  sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -317,12 +317,12 @@ module "config-eu-central-1" {
   providers = {
     aws = aws.eu-central-1
   }
-  iam_role_arn    = aws_iam_service_linked_role.config.arn
-  s3_bucket_id    = module.config-bucket.bucket.id
-  root_account_id = var.root_account_id
-  home_region     = data.aws_region.current.name
+  iam_role_arn       = aws_iam_service_linked_role.config.arn
+  s3_bucket_id       = module.config-bucket.bucket.id
+  root_account_id    = var.root_account_id
+  home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
-  sns_topic_key = aws_kms_key.config-sns-key.key_id
+  sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -338,12 +338,12 @@ module "config-eu-north-1" {
   providers = {
     aws = aws.eu-north-1
   }
-  iam_role_arn    = aws_iam_service_linked_role.config.arn
-  s3_bucket_id    = module.config-bucket.bucket.id
-  root_account_id = var.root_account_id
-  home_region     = data.aws_region.current.name
+  iam_role_arn       = aws_iam_service_linked_role.config.arn
+  s3_bucket_id       = module.config-bucket.bucket.id
+  root_account_id    = var.root_account_id
+  home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
-  sns_topic_key = aws_kms_key.config-sns-key.key_id
+  sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -359,12 +359,12 @@ module "config-eu-west-1" {
   providers = {
     aws = aws.eu-west-1
   }
-  iam_role_arn    = aws_iam_service_linked_role.config.arn
-  s3_bucket_id    = module.config-bucket.bucket.id
-  root_account_id = var.root_account_id
-  home_region     = data.aws_region.current.name
+  iam_role_arn       = aws_iam_service_linked_role.config.arn
+  s3_bucket_id       = module.config-bucket.bucket.id
+  root_account_id    = var.root_account_id
+  home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
-  sns_topic_key = aws_kms_key.config-sns-key.key_id
+  sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -380,12 +380,12 @@ module "config-eu-west-2" {
   providers = {
     aws = aws.eu-west-2
   }
-  iam_role_arn    = aws_iam_service_linked_role.config.arn
-  s3_bucket_id    = module.config-bucket.bucket.id
-  root_account_id = var.root_account_id
-  home_region     = data.aws_region.current.name
+  iam_role_arn       = aws_iam_service_linked_role.config.arn
+  s3_bucket_id       = module.config-bucket.bucket.id
+  root_account_id    = var.root_account_id
+  home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
-  sns_topic_key = aws_kms_key.config-sns-key.key_id
+  sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -401,12 +401,12 @@ module "config-eu-west-3" {
   providers = {
     aws = aws.eu-west-3
   }
-  iam_role_arn    = aws_iam_service_linked_role.config.arn
-  s3_bucket_id    = module.config-bucket.bucket.id
-  root_account_id = var.root_account_id
-  home_region     = data.aws_region.current.name
+  iam_role_arn       = aws_iam_service_linked_role.config.arn
+  s3_bucket_id       = module.config-bucket.bucket.id
+  root_account_id    = var.root_account_id
+  home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
-  sns_topic_key = aws_kms_key.config-sns-key.key_id
+  sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -422,12 +422,12 @@ module "config-sa-east-1" {
   providers = {
     aws = aws.sa-east-1
   }
-  iam_role_arn    = aws_iam_service_linked_role.config.arn
-  s3_bucket_id    = module.config-bucket.bucket.id
-  root_account_id = var.root_account_id
-  home_region     = data.aws_region.current.name
+  iam_role_arn       = aws_iam_service_linked_role.config.arn
+  s3_bucket_id       = module.config-bucket.bucket.id
+  root_account_id    = var.root_account_id
+  home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
-  sns_topic_key = aws_kms_key.config-sns-key.key_id
+  sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -443,12 +443,12 @@ module "config-us-east-1" {
   providers = {
     aws = aws.us-east-1
   }
-  iam_role_arn    = aws_iam_service_linked_role.config.arn
-  s3_bucket_id    = module.config-bucket.bucket.id
-  root_account_id = var.root_account_id
-  home_region     = data.aws_region.current.name
+  iam_role_arn       = aws_iam_service_linked_role.config.arn
+  s3_bucket_id       = module.config-bucket.bucket.id
+  root_account_id    = var.root_account_id
+  home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
-  sns_topic_key = aws_kms_key.config-sns-key.key_id
+  sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -464,12 +464,12 @@ module "config-us-east-2" {
   providers = {
     aws = aws.us-east-2
   }
-  iam_role_arn    = aws_iam_service_linked_role.config.arn
-  s3_bucket_id    = module.config-bucket.bucket.id
-  root_account_id = var.root_account_id
-  home_region     = data.aws_region.current.name
+  iam_role_arn       = aws_iam_service_linked_role.config.arn
+  s3_bucket_id       = module.config-bucket.bucket.id
+  root_account_id    = var.root_account_id
+  home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
-  sns_topic_key = aws_kms_key.config-sns-key.key_id
+  sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -485,12 +485,12 @@ module "config-us-west-1" {
   providers = {
     aws = aws.us-west-1
   }
-  iam_role_arn    = aws_iam_service_linked_role.config.arn
-  s3_bucket_id    = module.config-bucket.bucket.id
-  root_account_id = var.root_account_id
-  home_region     = data.aws_region.current.name
+  iam_role_arn       = aws_iam_service_linked_role.config.arn
+  s3_bucket_id       = module.config-bucket.bucket.id
+  root_account_id    = var.root_account_id
+  home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
-  sns_topic_key = aws_kms_key.config-sns-key.key_id
+  sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -506,12 +506,12 @@ module "config-us-west-2" {
   providers = {
     aws = aws.us-west-2
   }
-  iam_role_arn    = aws_iam_service_linked_role.config.arn
-  s3_bucket_id    = module.config-bucket.bucket.id
-  root_account_id = var.root_account_id
-  home_region     = data.aws_region.current.name
+  iam_role_arn       = aws_iam_service_linked_role.config.arn
+  s3_bucket_id       = module.config-bucket.bucket.id
+  root_account_id    = var.root_account_id
+  home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
-  sns_topic_key = aws_kms_key.config-sns-key.key_id
+  sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -519,4 +519,3 @@ module "config-us-west-2" {
   }
   tags = var.tags
 }
-

--- a/config.tf
+++ b/config.tf
@@ -1,102 +1,6 @@
-# AWS Config: configure an IAM role
-resource "aws_iam_role" "config" {
-  name               = "AWSConfig"
-  assume_role_policy = data.aws_iam_policy_document.config-assume-role-policy.json
-  tags               = var.tags
-}
 
-# AWS Config: assume role policy
-data "aws_iam_policy_document" "config-assume-role-policy" {
-  version = "2012-10-17"
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["config.amazonaws.com"]
-    }
-  }
-}
-
-# AWS Config: service role policy
-# See: https://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html
-resource "aws_iam_role_policy_attachment" "config-service-role-policy" {
-  role       = aws_iam_role.config.id
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
-}
-
-# AWS Config: publish to S3 and SNS policy
-resource "aws_iam_policy" "config-publish-policy" {
-  name   = "AWSConfigPublishPolicy"
-  policy = data.aws_iam_policy_document.config-publish-policy.json
-}
-
-# Extrapolated from:
-# https://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html and
-# https://docs.aws.amazon.com/config/latest/developerguide/sns-topic-policy.html
-#tfsec ignore appropriate as wildcard scoped to logs for single account
-#tfsec:ignore:aws-iam-no-policy-wildcards
-data "aws_iam_policy_document" "config-publish-policy" {
-  version = "2012-10-17"
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "s3:PutObject",
-      "s3:PutObjectAcl"
-    ]
-    resources = ["${module.config-bucket.bucket.arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"]
-
-    condition {
-      test     = "StringLike"
-      variable = "s3:x-amz-acl"
-      values   = ["bucket-owner-full-control"]
-    }
-  }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "s3:GetBucketAcl",
-      "s3:ListBucket"
-    ]
-    resources = [module.config-bucket.bucket.arn]
-  }
-
-  statement {
-    effect  = "Allow"
-    actions = ["sns:Publish"]
-    resources = flatten([
-      for enabled_region in [
-        module.config-ap-northeast-1,
-        module.config-ap-northeast-2,
-        module.config-ap-south-1,
-        module.config-ap-southeast-1,
-        module.config-ap-southeast-2,
-        module.config-ca-central-1,
-        module.config-eu-central-1,
-        module.config-eu-north-1,
-        module.config-eu-west-1,
-        module.config-eu-west-2,
-        module.config-eu-west-3,
-        module.config-sa-east-1,
-        module.config-us-east-1,
-        module.config-us-east-2,
-        module.config-us-west-1,
-        module.config-us-west-2
-        ] : [
-        for enabled_module in enabled_region : [
-          enabled_module.sns_topic_arn
-        ]
-      ]
-    ])
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "config-publish-policy" {
-  role       = aws_iam_role.config.id
-  policy_arn = aws_iam_policy.config-publish-policy.arn
+resource "aws_iam_service_linked_role" "config" {
+  aws_service_name = "config.amazonaws.com"
 }
 
 # AWS Config: configure an S3 bucket
@@ -153,16 +57,36 @@ module "config-bucket" {
 }
 
 # AWS Config: bucket policy, and require secure transport
-# Extrapolated from:
+# Source:
 # https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-policy.html
-# https://docs.aws.amazon.com/config/latest/developerguide/iamrole-permissions.html
 data "aws_iam_policy_document" "config-s3-policy" {
   version = "2012-10-17"
 
   statement {
+    sid = "AWSConfigBucketPermissionsCheck"
     effect = "Allow"
     actions = [
-      "s3:GetBucketAcl",
+      "s3:GetBucketAcl"
+    ]
+    resources = [module.config-bucket.bucket.arn]
+
+    principals {
+      identifiers = ["config.amazonaws.com"]
+      type        = "Service"
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [var.current_account_id]
+    }
+
+  }
+
+  statement {
+    sid = "AWSConfigBucketExistenceCheck"
+    effect = "Allow"
+    actions = [
       "s3:ListBucket"
     ]
     resources = [module.config-bucket.bucket.arn]
@@ -171,50 +95,93 @@ data "aws_iam_policy_document" "config-s3-policy" {
       identifiers = ["config.amazonaws.com"]
       type        = "Service"
     }
-  }
-
-  statement {
-    effect    = "Allow"
-    actions   = ["s3:PutObject"]
-    resources = ["${module.config-bucket.bucket.arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/Config/*"]
 
     condition {
       test     = "StringEquals"
-      variable = "s3:x-amz-acl"
-      values   = ["bucket-owner-full-control"]
+      variable = "aws:SourceAccount"
+      values   = [var.current_account_id]
     }
+
+  }
+
+  statement {
+    sid = "AWSConfigBucketDelivery"
+    effect    = "Allow"
+    actions   = [
+      "s3:PutObject"
+    ]
+    resources = ["${module.config-bucket.bucket.arn}/*"]
 
     principals {
       identifiers = ["config.amazonaws.com"]
       type        = "Service"
     }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [var.current_account_id]
+    }
+
+  }
+
+}
+
+# Add Multi-Region KMS and Policy for use by SNS
+# KMS Key & Policy for the SNS Topic. This is required for the user of a service-linked role.
+
+resource "aws_kms_key" "config-sns-key" {
+  description             = "KMS key for AWS Config SNS topic"
+  multi_region            = true
+  policy = data.aws_iam_policy_document.config-sns-key-policy.json
+}
+
+resource "aws_kms_alias" "config-sns-key-alias" {
+  name          = "alias/config-sns-key"
+  target_key_id = aws_kms_key.config-sns-key.key_id
+}
+
+data "aws_iam_policy_document" "config-sns-key-policy" {
+  #checkov:skip=CKV_AWS_109:"Policy is directly related to the resource"
+  #checkov:skip=CKV_AWS_111:"Policy is directly related to the resource"
+  #checkov:skip=CKV_AWS_356:"Policy is directly related to the resource"
+
+  statement {
+    sid    = "Allow management access of the key"
+    effect = "Allow"
+    actions = [
+      "kms:*"
+    ]
+    resources = [
+      "*"
+    ]
+    principals {
+      type = "AWS"
+      identifiers = [
+        var.current_account_id
+      ]
+    }
   }
 
   statement {
-    effect = "Allow"
-    actions = [
-      "s3:GetAccelerateConfiguration",
-      "s3:GetBucketAcl",
-      "s3:GetBucketCORS",
-      "s3:GetBucketLocation",
-      "s3:GetBucketLogging",
-      "s3:GetBucketNotification",
-      "s3:GetBucketPolicy",
-      "s3:GetBucketRequestPayment",
-      "s3:GetBucketTagging",
-      "s3:GetBucketVersioning",
-      "s3:GetBucketWebsite",
-      "s3:GetLifecycleConfiguration",
-      "s3:GetReplicationConfiguration"
-    ]
-    resources = [module.config-bucket.bucket.arn]
-
+    sid     = "AWSConfigSNSPolicy"
+    effect  = "Allow"
+    actions = ["kms:Decrypt", "kms:GenerateDataKey"]
+    resources = ["*"]
     principals {
-      identifiers = [aws_iam_role.config.arn]
-      type        = "AWS"
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [var.current_account_id]
     }
   }
+
 }
+
+
 
 # Enable Config in each region
 module "config-ap-northeast-1" {
@@ -224,10 +191,12 @@ module "config-ap-northeast-1" {
   providers = {
     aws = aws.ap-northeast-1
   }
-  iam_role_arn    = aws_iam_role.config.arn
+  iam_role_arn    = aws_iam_service_linked_role.config.arn
   s3_bucket_id    = module.config-bucket.bucket.id
   root_account_id = var.root_account_id
   home_region     = data.aws_region.current.name
+  current_account_id = var.current_account_id
+  sns_topic_key = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -243,10 +212,12 @@ module "config-ap-northeast-2" {
   providers = {
     aws = aws.ap-northeast-2
   }
-  iam_role_arn    = aws_iam_role.config.arn
+  iam_role_arn    = aws_iam_service_linked_role.config.arn
   s3_bucket_id    = module.config-bucket.bucket.id
   root_account_id = var.root_account_id
   home_region     = data.aws_region.current.name
+  current_account_id = var.current_account_id
+  sns_topic_key = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -262,10 +233,12 @@ module "config-ap-south-1" {
   providers = {
     aws = aws.ap-south-1
   }
-  iam_role_arn    = aws_iam_role.config.arn
+  iam_role_arn    = aws_iam_service_linked_role.config.arn
   s3_bucket_id    = module.config-bucket.bucket.id
   root_account_id = var.root_account_id
   home_region     = data.aws_region.current.name
+  current_account_id = var.current_account_id
+  sns_topic_key = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -281,10 +254,12 @@ module "config-ap-southeast-1" {
   providers = {
     aws = aws.ap-southeast-1
   }
-  iam_role_arn    = aws_iam_role.config.arn
+  iam_role_arn    = aws_iam_service_linked_role.config.arn
   s3_bucket_id    = module.config-bucket.bucket.id
   root_account_id = var.root_account_id
   home_region     = data.aws_region.current.name
+  current_account_id = var.current_account_id
+  sns_topic_key = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -300,10 +275,12 @@ module "config-ap-southeast-2" {
   providers = {
     aws = aws.ap-southeast-2
   }
-  iam_role_arn    = aws_iam_role.config.arn
+  iam_role_arn    = aws_iam_service_linked_role.config.arn
   s3_bucket_id    = module.config-bucket.bucket.id
   root_account_id = var.root_account_id
   home_region     = data.aws_region.current.name
+  current_account_id = var.current_account_id
+  sns_topic_key = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -319,10 +296,12 @@ module "config-ca-central-1" {
   providers = {
     aws = aws.ca-central-1
   }
-  iam_role_arn    = aws_iam_role.config.arn
+  iam_role_arn    = aws_iam_service_linked_role.config.arn
   s3_bucket_id    = module.config-bucket.bucket.id
   root_account_id = var.root_account_id
   home_region     = data.aws_region.current.name
+  current_account_id = var.current_account_id  
+  sns_topic_key = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -338,10 +317,12 @@ module "config-eu-central-1" {
   providers = {
     aws = aws.eu-central-1
   }
-  iam_role_arn    = aws_iam_role.config.arn
+  iam_role_arn    = aws_iam_service_linked_role.config.arn
   s3_bucket_id    = module.config-bucket.bucket.id
   root_account_id = var.root_account_id
   home_region     = data.aws_region.current.name
+  current_account_id = var.current_account_id
+  sns_topic_key = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -357,10 +338,12 @@ module "config-eu-north-1" {
   providers = {
     aws = aws.eu-north-1
   }
-  iam_role_arn    = aws_iam_role.config.arn
+  iam_role_arn    = aws_iam_service_linked_role.config.arn
   s3_bucket_id    = module.config-bucket.bucket.id
   root_account_id = var.root_account_id
   home_region     = data.aws_region.current.name
+  current_account_id = var.current_account_id
+  sns_topic_key = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -376,10 +359,12 @@ module "config-eu-west-1" {
   providers = {
     aws = aws.eu-west-1
   }
-  iam_role_arn    = aws_iam_role.config.arn
+  iam_role_arn    = aws_iam_service_linked_role.config.arn
   s3_bucket_id    = module.config-bucket.bucket.id
   root_account_id = var.root_account_id
   home_region     = data.aws_region.current.name
+  current_account_id = var.current_account_id
+  sns_topic_key = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -395,10 +380,12 @@ module "config-eu-west-2" {
   providers = {
     aws = aws.eu-west-2
   }
-  iam_role_arn    = aws_iam_role.config.arn
+  iam_role_arn    = aws_iam_service_linked_role.config.arn
   s3_bucket_id    = module.config-bucket.bucket.id
   root_account_id = var.root_account_id
   home_region     = data.aws_region.current.name
+  current_account_id = var.current_account_id
+  sns_topic_key = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -414,10 +401,12 @@ module "config-eu-west-3" {
   providers = {
     aws = aws.eu-west-3
   }
-  iam_role_arn    = aws_iam_role.config.arn
+  iam_role_arn    = aws_iam_service_linked_role.config.arn
   s3_bucket_id    = module.config-bucket.bucket.id
   root_account_id = var.root_account_id
   home_region     = data.aws_region.current.name
+  current_account_id = var.current_account_id
+  sns_topic_key = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -433,10 +422,12 @@ module "config-sa-east-1" {
   providers = {
     aws = aws.sa-east-1
   }
-  iam_role_arn    = aws_iam_role.config.arn
+  iam_role_arn    = aws_iam_service_linked_role.config.arn
   s3_bucket_id    = module.config-bucket.bucket.id
   root_account_id = var.root_account_id
   home_region     = data.aws_region.current.name
+  current_account_id = var.current_account_id
+  sns_topic_key = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -452,10 +443,12 @@ module "config-us-east-1" {
   providers = {
     aws = aws.us-east-1
   }
-  iam_role_arn    = aws_iam_role.config.arn
+  iam_role_arn    = aws_iam_service_linked_role.config.arn
   s3_bucket_id    = module.config-bucket.bucket.id
   root_account_id = var.root_account_id
   home_region     = data.aws_region.current.name
+  current_account_id = var.current_account_id
+  sns_topic_key = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -471,10 +464,12 @@ module "config-us-east-2" {
   providers = {
     aws = aws.us-east-2
   }
-  iam_role_arn    = aws_iam_role.config.arn
+  iam_role_arn    = aws_iam_service_linked_role.config.arn
   s3_bucket_id    = module.config-bucket.bucket.id
   root_account_id = var.root_account_id
   home_region     = data.aws_region.current.name
+  current_account_id = var.current_account_id
+  sns_topic_key = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -490,10 +485,12 @@ module "config-us-west-1" {
   providers = {
     aws = aws.us-west-1
   }
-  iam_role_arn    = aws_iam_role.config.arn
+  iam_role_arn    = aws_iam_service_linked_role.config.arn
   s3_bucket_id    = module.config-bucket.bucket.id
   root_account_id = var.root_account_id
   home_region     = data.aws_region.current.name
+  current_account_id = var.current_account_id
+  sns_topic_key = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket
@@ -509,10 +506,12 @@ module "config-us-west-2" {
   providers = {
     aws = aws.us-west-2
   }
-  iam_role_arn    = aws_iam_role.config.arn
+  iam_role_arn    = aws_iam_service_linked_role.config.arn
   s3_bucket_id    = module.config-bucket.bucket.id
   root_account_id = var.root_account_id
   home_region     = data.aws_region.current.name
+  current_account_id = var.current_account_id
+  sns_topic_key = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
     cloudwatch_log_group_arn = module.cloudtrail.cloudwatch_log_group_arn
     s3_bucket_id             = local.cloudtrail_bucket

--- a/config.tf
+++ b/config.tf
@@ -153,7 +153,7 @@ data "aws_iam_policy_document" "config-sns-key-policy" {
       "kms:*"
     ]
     resources = [
-      "*"
+      "${aws_kms_key.config-sns-key.arn}",
     ]
     principals {
       type = "AWS"

--- a/modules/config/README.md
+++ b/modules/config/README.md
@@ -17,6 +17,8 @@ module "config" {
 | root_account_id | The AWS Organisations root account ID that this account should be part of | string | | yes |
 | iam_role_arn | IAM role ARN for the AWS Config service role | string | | yes |
 | s3_bucket_id | S3 bucket ID for AWS Config to publish to | string | | yes |
+| current_account_id | The value of the account ID into which this module is deployed | | yes |
+| sns_topic_key | The arn of the KMS policy to be used by the SNS topic | | yes |
 | home_region | Region to enable AWS Config rules for global resources, such as IAM. Currently taken from the calling region | string | | yes |
 | tags | Tags to apply to resources | map | {} | no |
 

--- a/modules/config/main.tf
+++ b/modules/config/main.tf
@@ -44,7 +44,7 @@ resource "aws_sns_topic" "default" {
 ## Add Policy for the SNS Topic.
 
 resource "aws_sns_topic_policy" "config-sns-policy" {
-  arn = aws_sns_topic.default.arn
+  arn    = aws_sns_topic.default.arn
   policy = data.aws_iam_policy_document.config-sns-policy.json
 }
 
@@ -52,9 +52,9 @@ data "aws_iam_policy_document" "config-sns-policy" {
   version = "2012-10-17"
 
   statement {
-    sid     = "AllowConfigPublish"
-    effect  = "Allow"
-    actions = ["sns:Publish"]
+    sid       = "AllowConfigPublish"
+    effect    = "Allow"
+    actions   = ["sns:Publish"]
     resources = [aws_sns_topic.default.arn]
 
     principals {
@@ -70,9 +70,9 @@ data "aws_iam_policy_document" "config-sns-policy" {
   }
 
   statement {
-    sid     = "AllowEventsPublish"
-    effect  = "Allow"
-    actions = ["sns:Publish"]
+    sid       = "AllowEventsPublish"
+    effect    = "Allow"
+    actions   = ["sns:Publish"]
     resources = [aws_sns_topic.default.arn]
 
     principals {

--- a/modules/config/main.tf
+++ b/modules/config/main.tf
@@ -37,8 +37,56 @@ resource "aws_config_configuration_recorder_status" "default" {
 # tfsec:ignore:aws-sns-topic-encryption-use-cmk
 resource "aws_sns_topic" "default" {
   name              = "config"
-  kms_master_key_id = "alias/aws/sns"
+  kms_master_key_id = var.sns_topic_key
   tags              = var.tags
+}
+
+## Add Policy for the SNS Topic.
+
+resource "aws_sns_topic_policy" "config-sns-policy" {
+  arn = aws_sns_topic.default.arn
+  policy = data.aws_iam_policy_document.config-sns-policy.json
+}
+
+data "aws_iam_policy_document" "config-sns-policy" {
+  version = "2012-10-17"
+
+  statement {
+    sid     = "AllowConfigPublish"
+    effect  = "Allow"
+    actions = ["sns:Publish"]
+    resources = [aws_sns_topic.default.arn]
+
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [var.current_account_id]
+    }
+  }
+
+  statement {
+    sid     = "AllowEventsPublish"
+    effect  = "Allow"
+    actions = ["sns:Publish"]
+    resources = [aws_sns_topic.default.arn]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [var.current_account_id]
+    }
+  }
+
 }
 
 # Configure AWS Config rules

--- a/modules/config/variables.tf
+++ b/modules/config/variables.tf
@@ -10,7 +10,7 @@ variable "root_account_id" {
 
 variable "current_account_id" {
   description = "value of the current account ID"
-  type = string
+  type        = string
 }
 
 variable "iam_role_arn" {
@@ -29,7 +29,7 @@ variable "home_region" {
 }
 
 variable "sns_topic_key" {
-  type = string
+  type        = string
   description = "value of the multi-region SNS topic key ARN"
 }
 

--- a/modules/config/variables.tf
+++ b/modules/config/variables.tf
@@ -8,6 +8,11 @@ variable "root_account_id" {
   type        = string
 }
 
+variable "current_account_id" {
+  description = "value of the current account ID"
+  type = string
+}
+
 variable "iam_role_arn" {
   description = "IAM role ARN for the AWS Config service role"
   type        = string
@@ -21,6 +26,11 @@ variable "s3_bucket_id" {
 variable "home_region" {
   type        = string
   description = "Region to enable AWS Config rules for global resources, such as IAM. Currently taken from the calling region"
+}
+
+variable "sns_topic_key" {
+  type = string
+  description = "value of the multi-region SNS topic key ARN"
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -50,6 +50,11 @@ variable "root_account_id" {
   description = "The AWS Organisations root account ID that this account should be part of"
 }
 
+variable "current_account_id" {
+  description = "value of the current account ID"
+  type        = string
+}
+
 variable "tags" {
   default     = {}
   description = "Tags to apply to resources, where applicable"


### PR DESCRIPTION
This PR covers the requirement to replace the existing IAM role & policy used by AWS Config with the service-linked role (AWSServiceRoleForConfig). To support this, changes were made to the s3 & sns policies & a multi-region CMK & policy were added as the service-linked role lacks the permissions to use default sns encryption.
Additional variables have also been added to both the overall module & the config sub-module - see the changes to the relevant READMEs.
This has been extensively tested in sprinkler.
A new release will be created for these changes.