### PR TITLE
Fixes cyclical issue with using the key arn.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -153,7 +153,7 @@ data "aws_iam_policy_document" "config-sns-key-policy" {
       "kms:*"
     ]
     resources = [
-      "${aws_kms_key.config-sns-key.arn}",
+      "*",
     ]
     principals {
       type = "AWS"


### PR DESCRIPTION
This fixes an issue whereby the reference to the key ARN in the key policy was creating a circular reference in the plan as shown by this error:
```
Error: Cycle: module.baselines.data.aws_iam_policy_document.config-sns-key-policy, module.baselines.aws_kms_key.config-sns-key
```

This was not picked up the previous round of testing as the key had already been created in sprinkler when that statement in the policy was added.