### PR TITLE
Forcibly set bypass safety check to false to work around provider error

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -131,9 +131,10 @@ data "aws_iam_policy_document" "config-s3-policy" {
 # KMS Key & Policy for the SNS Topic. This is required for the user of a service-linked role.
 
 resource "aws_kms_key" "config-sns-key" {
-  description  = "KMS key for AWS Config SNS topic"
-  multi_region = true
-  policy       = data.aws_iam_policy_document.config-sns-key-policy.json
+  bypass_policy_lockout_safety_check = false
+  description                        = "KMS key for AWS Config SNS topic"
+  multi_region                       = true
+  policy                             = data.aws_iam_policy_document.config-sns-key-policy.json
 }
 
 resource "aws_kms_alias" "config-sns-key-alias" {

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -10,12 +10,13 @@ data "aws_region" "current" {}
 
 # Backup alarms KMS multi-Region
 resource "aws_kms_key" "backup_alarms_multi_region" {
-  deletion_window_in_days = 7
-  description             = "Backup alarms encryption key"
-  enable_key_rotation     = true
-  policy                  = data.aws_iam_policy_document.backup-alarms-kms.json
-  tags                    = var.tags
-  multi_region            = true
+  bypass_policy_lockout_safety_check = false
+  deletion_window_in_days            = 7
+  description                        = "Backup alarms encryption key"
+  enable_key_rotation                = true
+  policy                             = data.aws_iam_policy_document.backup-alarms-kms.json
+  tags                               = var.tags
+  multi_region                       = true
 }
 
 resource "aws_kms_alias" "backup_alarms_multi_region" {

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -3,11 +3,12 @@ data "aws_caller_identity" "current" {}
 # AWS CloudWatch doesn't support using the AWS-managed KMS key for publishing things from CloudWatch to SNS
 # See: https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-receive-sns-for-alarm-trigger/
 resource "aws_kms_key" "securityhub-alarms" {
-  deletion_window_in_days = 7
-  description             = "SecurityHub alarms encryption key"
-  enable_key_rotation     = true
-  policy                  = data.aws_iam_policy_document.securityhub-alarms-kms.json
-  tags                    = var.tags
+  bypass_policy_lockout_safety_check = false
+  deletion_window_in_days            = 7
+  description                        = "SecurityHub alarms encryption key"
+  enable_key_rotation                = true
+  policy                             = data.aws_iam_policy_document.securityhub-alarms-kms.json
+  tags                               = var.tags
 }
 
 resource "aws_kms_alias" "securityhub-alarms" {

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -18,12 +18,13 @@ resource "aws_kms_alias" "securityhub-alarms" {
 
 # SecurityHub alarms KMS multi-Region
 resource "aws_kms_key" "securityhub_alarms_multi_region" {
-  deletion_window_in_days = 7
-  description             = "SecurityHub alarms encryption key"
-  enable_key_rotation     = true
-  policy                  = data.aws_iam_policy_document.securityhub-alarms-kms.json
-  tags                    = var.tags
-  multi_region            = true
+  bypass_policy_lockout_safety_check = false
+  deletion_window_in_days            = 7
+  description                        = "SecurityHub alarms encryption key"
+  enable_key_rotation                = true
+  policy                             = data.aws_iam_policy_document.securityhub-alarms-kms.json
+  tags                               = var.tags
+  multi_region                       = true
 }
 
 resource "aws_kms_alias" "securityhub_alarms_multi_region" {

--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -167,10 +167,11 @@ data "aws_iam_policy_document" "sechub_findings_sns_topic_policy" {
 
 # Create CMK to encrypt SNS topic
 resource "aws_kms_key" "sns_kms_key" {
-  count               = var.enable_securityhub_alerts ? 1 : 0
-  description         = "KMS key for SNS topic encryption"
-  enable_key_rotation = true
-  policy              = data.aws_iam_policy_document.sns_kms.json
+  bypass_policy_lockout_safety_check = false
+  count                              = var.enable_securityhub_alerts ? 1 : 0
+  description                        = "KMS key for SNS topic encryption"
+  enable_key_rotation                = true
+  policy                             = data.aws_iam_policy_document.sns_kms.json
 }
 
 resource "aws_kms_alias" "sns_kms_alias" {

--- a/test/cloudtrail-test/main.tf
+++ b/test/cloudtrail-test/main.tf
@@ -12,10 +12,11 @@ module "cloudtrail-test" {
 
 # Cloudtrail KMS
 resource "aws_kms_key" "cloudtrail_kms_key" {
-  deletion_window_in_days = 7
-  description             = "Cloudtrail encryption key"
-  enable_key_rotation     = true
-  policy                  = data.aws_iam_policy_document.cloudtrail_kms.json
+  bypass_policy_lockout_safety_check = false
+  deletion_window_in_days            = 7
+  description                        = "Cloudtrail encryption key"
+  enable_key_rotation                = true
+  policy                             = data.aws_iam_policy_document.cloudtrail_kms.json
 }
 
 resource "aws_kms_alias" "cloudtrail_kms_alias" {

--- a/test/cloudtrail-test/s3_cloudtrail.tf
+++ b/test/cloudtrail-test/s3_cloudtrail.tf
@@ -1,4 +1,12 @@
+# trivy:ignore:AVD-AWS-0088
+# trivy:ignore:AVD-AWS-0132
 resource "aws_s3_bucket" "cloudtrail_s3_bucket" {
+# checkov:skip=CKV_AWS_18: Ephemeral bucket used for tests
+# checkov:skip=CKV_AWS_21
+# checkov:skip=CKV_AWS_144
+# checkov:skip=CKV_AWS_145
+# checkov:skip=CKV2_AWS_61
+# checkov:skip=CKV2_AWS_62
   bucket_prefix = var.cloudtrail_bucket
   force_destroy = true
   tags          = local.tags

--- a/test/cloudtrail-test/s3_cloudtrail.tf
+++ b/test/cloudtrail-test/s3_cloudtrail.tf
@@ -1,12 +1,12 @@
 # trivy:ignore:AVD-AWS-0088
 # trivy:ignore:AVD-AWS-0132
 resource "aws_s3_bucket" "cloudtrail_s3_bucket" {
-# checkov:skip=CKV_AWS_18: Ephemeral bucket used for tests
-# checkov:skip=CKV_AWS_21
-# checkov:skip=CKV_AWS_144
-# checkov:skip=CKV_AWS_145
-# checkov:skip=CKV2_AWS_61
-# checkov:skip=CKV2_AWS_62
+  # checkov:skip=CKV_AWS_18: Ephemeral bucket used for tests
+  # checkov:skip=CKV_AWS_21
+  # checkov:skip=CKV_AWS_144
+  # checkov:skip=CKV_AWS_145
+  # checkov:skip=CKV2_AWS_61
+  # checkov:skip=CKV2_AWS_62
   bucket_prefix = var.cloudtrail_bucket
   force_destroy = true
   tags          = local.tags

--- a/test/cloudtrail-test/s3_cloudtrail.tf
+++ b/test/cloudtrail-test/s3_cloudtrail.tf
@@ -1,7 +1,16 @@
 resource "aws_s3_bucket" "cloudtrail_s3_bucket" {
-  bucket        = var.cloudtrail_bucket
+  bucket_prefix = var.cloudtrail_bucket
   force_destroy = true
   tags          = local.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "cloudtrail_s3_bucket" {
+  bucket = aws_s3_bucket.cloudtrail_s3_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 resource "aws_s3_bucket_policy" "s3_cloudtrail_policy" {


### PR DESCRIPTION
We've seen intermittent AWS Provider errors like so when using this module:
```
Error: Provider produced inconsistent final plan

When expanding the plan for
module.baselines.module.securityhub-alarms.aws_kms_key.securityhub-alarms to
include new values learned so far during apply, provider
"registry.terraform.io/hashicorp/aws" produced an invalid new value for
.bypass_policy_lockout_safety_check: was cty.False, but now null.

This is a bug in the provider, which should be reported in the provider's own
issue tracker.
```

From an investigation of the Terraform code which creates these resources, we can see that they are specified as `false` by default, but the existence of this error might be related to a migration to the Terraform Plugin Framework? It's been seen in a few Terraform issues (eg https://github.com/hashicorp/terraform-provider-aws/issues/34902).

This PR specifies the value as `false` to ensure that it is consistently applied.