### PR TITLE
Replace alias data call with terraform workspace call

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -2,5 +2,4 @@ locals {
   enabled           = toset(["enabled"])
   not_enabled       = toset([])
   cloudtrail_bucket = "modernisation-platform-logs-cloudtrail"
-  account_alias     = data.aws_iam_account_alias.current.account_alias
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,5 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
-data "aws_iam_account_alias" "current" {}
-
 module "cloudtrail" {
   source = "./modules/cloudtrail"
   providers = {
@@ -29,21 +27,21 @@ module "securityhub-alarms" {
   depends_on = [module.cloudtrail]
 
   # Add alias to alarm names
-  unauthorised_api_calls_log_metric_filter_name       = "unauthorised-api-calls-${local.account_alias}"
-  sign_in_without_mfa_metric_filter_name              = "sign-in-without-mfa-${local.account_alias}"
-  root_account_usage_metric_filter_name               = "root-account-usage-${local.account_alias}"
-  iam_policy_changes_metric_filter_name               = "iam-policy-changes-${local.account_alias}"
-  cloudtrail_configuration_changes_metric_filter_name = "cloudtrail-configuration-changes-${local.account_alias}"
-  sign_in_failures_metric_filter_name                 = "sign-in-failures-${local.account_alias}"
-  cmk_removal_metric_filter_name                      = "cmk-removal-${local.account_alias}"
-  s3_bucket_policy_changes_metric_filter_name         = "s3-bucket-policy-changes-${local.account_alias}"
-  config_configuration_changes_metric_filter_name     = "config-configuration-changes-${local.account_alias}"
-  security_group_changes_metric_filter_name           = "security-group-changes-${local.account_alias}"
-  nacl_changes_metric_filter_name                     = "nacl-changes-${local.account_alias}"
-  network_gateway_changes_metric_filter_name          = "network-gateway-changes-${local.account_alias}"
-  route_table_changes_metric_filter_name              = "route-table-changes-${local.account_alias}"
-  vpc_changes_metric_filter_name                      = "vpc-changes-${local.account_alias}"
-  admin_role_usage_metric_filter_name                 = "admin-role-usage-${local.account_alias}"
+  unauthorised_api_calls_log_metric_filter_name       = "unauthorised-api-calls-${terraform.workspace}"
+  sign_in_without_mfa_metric_filter_name              = "sign-in-without-mfa-${terraform.workspace}"
+  root_account_usage_metric_filter_name               = "root-account-usage-${terraform.workspace}"
+  iam_policy_changes_metric_filter_name               = "iam-policy-changes-${terraform.workspace}"
+  cloudtrail_configuration_changes_metric_filter_name = "cloudtrail-configuration-changes-${terraform.workspace}"
+  sign_in_failures_metric_filter_name                 = "sign-in-failures-${terraform.workspace}"
+  cmk_removal_metric_filter_name                      = "cmk-removal-${terraform.workspace}"
+  s3_bucket_policy_changes_metric_filter_name         = "s3-bucket-policy-changes-${terraform.workspace}"
+  config_configuration_changes_metric_filter_name     = "config-configuration-changes-${terraform.workspace}"
+  security_group_changes_metric_filter_name           = "security-group-changes-${terraform.workspace}"
+  nacl_changes_metric_filter_name                     = "nacl-changes-${terraform.workspace}"
+  network_gateway_changes_metric_filter_name          = "network-gateway-changes-${terraform.workspace}"
+  route_table_changes_metric_filter_name              = "route-table-changes-${terraform.workspace}"
+  vpc_changes_metric_filter_name                      = "vpc-changes-${terraform.workspace}"
+  admin_role_usage_metric_filter_name                 = "admin-role-usage-${terraform.workspace}"
 
   tags = var.tags
 }


### PR DESCRIPTION
## Why?

`v7.12.0` rollout failed https://github.com/ministryofjustice/modernisation-platform/actions/runs/13367813632

If there is no account alias set you get the error...

```
Error: reading IAM Account Alias: empty result

  with module.baselines.data.aws_iam_account_alias.current
```

## What's changed?

Instead of using the alias data call I've replaced it with just using `terraform.workspace` which is much simple, will always work and is more robust (why didn't I do that in the first place!?)