### PR TITLE
Tuning CloudWatch alarms

### DIFF
--- a/modules/securityhub-alarms/README.md
+++ b/modules/securityhub-alarms/README.md
@@ -1,6 +1,6 @@
-# SecurityHub Alarms
+# CloudWatch Alarms
 
-Terraform module for creating CloudWatch Alarms for SecurityHub that comply with the CIS AWS Foundations Benchmark v1.2.0 rules, which are:
+Terraform module for creating CloudWatch Alarms that comply with the CIS AWS Foundations Benchmark v1.2.0 rules, which are:
 
 - [x] [1.1 – Avoid the use of the "root" account](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html#cis-1.1-remediation) as a by-product of [CIS 3.3 remediation](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html/cis-3.3-remediation)
 - [x] [3.1 - Ensure a log metric filter and alarm exist for unauthorized API calls](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html/cis-3.1-remediation)
@@ -17,6 +17,10 @@ Terraform module for creating CloudWatch Alarms for SecurityHub that comply with
 - [x] [3.12  - Ensure a log metric filter and alarm exist for changes to network gateways](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html/cis-3.12-remediation)
 - [x] [3.13  - Ensure a log metric filter and alarm exist for route table changes](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html/cis-3.13-remediation)
 - [x] [3.14  - Ensure a log metric filter and alarm exist for VPC changes](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html/cis-3.14-remediation)
+
+Security Hub has dedicated controls which check that these alarms/metric filters exist to show our compliance with the benchmark. It should be noted that these controls have been [removed](https://docs.aws.amazon.com/securityhub/latest/userguide/cis-aws-foundations-benchmark.html) for later versions of the benchmark (e.g. v3.0.0) if we decide to upgrade the security standards in future.
+
+The module also generates some extra alarms that are of benefit to the Modernisation Platform team e.g. monitoring use of the Administrator role.
 
 ## Usage
 

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -194,7 +194,7 @@ resource "aws_cloudwatch_log_metric_filter" "iam-policy-changes" {
 resource "aws_cloudwatch_metric_alarm" "iam-policy-changes" {
   alarm_name        = var.iam_policy_changes_alarm_name
   alarm_description = "Monitors for IAM policy changes."
-  alarm_actions     = [aws_sns_topic.securityhub-alarms.arn]
+  alarm_actions     = []
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -224,7 +224,7 @@ resource "aws_cloudwatch_log_metric_filter" "cloudtrail-configuration-changes" {
 resource "aws_cloudwatch_metric_alarm" "cloudtrail-configuration-changes" {
   alarm_name        = var.cloudtrail_configuration_changes_alarm_name
   alarm_description = "Monitors for CloudTrail configuration changes."
-  alarm_actions     = [aws_sns_topic.securityhub-alarms.arn]
+  alarm_actions     = []
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -284,7 +284,7 @@ resource "aws_cloudwatch_log_metric_filter" "cmk-removal" {
 resource "aws_cloudwatch_metric_alarm" "cmk-removal" {
   alarm_name        = var.cmk_removal_alarm_name
   alarm_description = "Monitors for AWS KMS customer-created CMK removal (deletion or disabled)."
-  alarm_actions     = [aws_sns_topic.securityhub-alarms.arn]
+  alarm_actions     = local.alarm_action
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -314,7 +314,7 @@ resource "aws_cloudwatch_log_metric_filter" "s3-bucket-policy-changes" {
 resource "aws_cloudwatch_metric_alarm" "s3-bucket-policy-changes" {
   alarm_name        = var.s3_bucket_policy_changes_alarm_name
   alarm_description = "Monitors for AWS S3 bucket policy changes."
-  alarm_actions     = [aws_sns_topic.securityhub-alarms.arn]
+  alarm_actions     = []
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -344,7 +344,7 @@ resource "aws_cloudwatch_log_metric_filter" "config-configuration-changes" {
 resource "aws_cloudwatch_metric_alarm" "config-configuration-changes" {
   alarm_name        = var.config_configuration_changes_alarm_name
   alarm_description = "Monitors for AWS Config configuration changes."
-  alarm_actions     = [aws_sns_topic.securityhub-alarms.arn]
+  alarm_actions     = []
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -374,7 +374,7 @@ resource "aws_cloudwatch_log_metric_filter" "security-group-changes" {
 resource "aws_cloudwatch_metric_alarm" "security-group-changes" {
   alarm_name        = var.security_group_changes_alarm_name
   alarm_description = "Monitors for AWS EC2 Security Group changes."
-  alarm_actions     = [aws_sns_topic.securityhub-alarms.arn]
+  alarm_actions     = []
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -626,7 +626,7 @@ resource "aws_cloudwatch_metric_alarm" "privatelink_service_active_connection_co
 
 resource "aws_cloudwatch_log_metric_filter" "admin_role_usage" {
   name           = var.admin_role_usage_metric_filter_name
-  pattern        = "{ $.eventName = \"AssumeRoleWithSAML\" && $.requestParameters.roleArn = \"*AdministratorAccess*\" }"
+  pattern        = "{ $.eventName = \"AssumeRoleWithSAML\" && $.requestParameters.roleArn = \"*AdministratorAccess*\" && $.requestParameters.principalTags.github_team = \"*modernisation-platform-engineers*\" }"
   log_group_name = "cloudtrail"
 
   metric_transformation {


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform/issues/9299

## What's Changing?
1. Updates alarm actions based on a review of what is most important for MP to be alerted on. For some alarms we only alert for our core accounts (e.g. unauthorised-api-access), for some we alert all accounts (e.g. root-account-usage) and for some I've turned it off all together to avoid duplication as we have other more intelligent alerts via SecHub etc. (e.g. security-group-changes) 
2. Updates admin usage alarm to only filter on MP usage of the role by filtering on GH team membership. At present we see this for other users of this role which we are less interested in.
3. Updates the module ReadMe to better explain what the module does