### PR TITLE
issue/9609

### DIFF
--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -658,7 +658,7 @@ resource "aws_cloudwatch_metric_alarm" "admin_role_usage" {
 
 resource "aws_cloudwatch_log_metric_filter" "orgaccess_role_usage" {
   name           = var.orgaccess_role_usage_metric_filter_name
-  pattern        = "{ $.eventName = \"AssumeRole*\" && $.requestParameters.roleArn = \"*OrganizationAccountAccessRole*\" }"
+  pattern        = "{ $.eventName = \"AssumeRole*\" && $.requestParameters.roleArn = \"*OrganizationAccountAccessRole*\" && $.requestParameters.roleSessionName = \"*justice.gov.uk*\" }"
   log_group_name = "cloudtrail"
 
   metric_transformation {


### PR DESCRIPTION
This amends the metric filter `orgaccess_role_usage` so that it only includes events where the role is assumed by an SSO user and not by github action or an internal AWS event.