### PR TITLE
Add Dependabot Directories and Grouping

### DIFF
--- a/scripts/generate-dependabot-file.sh
+++ b/scripts/generate-dependabot-file.sh
@@ -1,28 +1,23 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 set -euo pipefail
 
-dependabot_file=.github/dependabot.yml
+dependabot_file=".github/dependabot.yml"
 
 # Clear the dependabot file
-> $dependabot_file
+> "$dependabot_file"
 
-# Get a list of Terraform folders
-all_tf_folders=`find . -type f -name '*.tf' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
-all_env_test_folders=`find . -type f -name 'go.mod' | sed 's#/[^/]*$##' | sed 's/.\///'| sort | uniq`
-echo
-echo "All TF folders"
-echo $all_tf_folders
-echo
-echo "All environment test folders"
-echo $all_env_test_folders
+echo "Scanning for Terraform files..."
+# Find all directories containing .tf files, excluding .terraform
+tf_dirs=$(find . -type f -name "*.tf" ! -path "*/.terraform/*" -exec dirname {} \; | sed 's|^\./||' | sort -u)
+
+# Find all directories containing go.mod files, excluding .terraform
+gomod_dirs=$(find . -type f -name "go.mod" ! -path "*/.terraform/*" -exec dirname {} \; | sed 's|^\./||' | sort -u)
 
 echo "Writing dependabot.yml file"
-# Creates a dependabot file to avoid having to manually add each new TF folder or go.mod file
-# Add any additional fixed entries in this top section
-  cat > $dependabot_file << EOL
-# This file is auto-generated here, do not manually amend. 
-# https://github.com/ministryofjustice/modernisation-platform/blob/main/scripts/generate-dependabot.sh
+
+cat > "$dependabot_file" << EOL
+# This file is auto-generated, do not manually amend.
+# https://github.com/ministryofjustice/modernisation-platform-terraform-baselines/blob/main/scripts/generate-dependabot-file.sh
 
 version: 2
 
@@ -31,25 +26,44 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  # Dependabot doesn't currently support wildcard or multiple directory declarations within
-  # a dependabot configuration, so we need to add all directories individually
-  # See: github.com/dependabot/dependabot-core/issues/2178
+    groups:
+      action-dependencies:
+        patterns:
+          - "*"
 EOL
 
-for folder in $all_tf_folders
-do
-echo "Generating entry for ${folder}"
-echo "  - package-ecosystem: \"terraform\"" >> $dependabot_file
-echo "    directory: \"/${folder}\"" >> $dependabot_file
-echo "    schedule:" >> $dependabot_file
-echo "      interval: \"daily\"" >> $dependabot_file
-done
+# Add Terraform ecosystem entries (dynamically only for top-level directories containing .tf files)
+if [[ -n "$tf_dirs" ]]; then
+  echo "Generating Terraform ecosystem entry..."
+  echo "  - package-ecosystem: \"terraform\"" >> "$dependabot_file"
+  echo "    directories:" >> "$dependabot_file"
 
-for folder in $all_env_test_folders
-do
-echo "Generating entry for ${folder}"
-echo "  - package-ecosystem: \"gomod\"" >> $dependabot_file
-echo "    directory: \"/${folder}\"" >> $dependabot_file
-echo "    schedule:" >> $dependabot_file
-echo "      interval: \"daily\"" >> $dependabot_file
-done
+  # Extract only top-level directories and ensure we don't add duplicates
+  echo "$tf_dirs" | awk -F/ '{print $1}' | sort -u | while IFS= read -r dir; do
+    echo "      - \"$dir/**/*\"" >> "$dependabot_file"
+  done
+  
+  echo "    schedule:" >> "$dependabot_file"
+  echo "      interval: \"daily\"" >> "$dependabot_file"
+fi
+
+# Add Go module ecosystem entries (dynamically only for top-level directories containing go.mod)
+if [[ -n "$gomod_dirs" ]]; then
+  echo "Generating Go module ecosystem entry..."
+  echo "  - package-ecosystem: \"gomod\"" >> "$dependabot_file"
+  echo "    directories:" >> "$dependabot_file"
+
+  # Extract only top-level directories and ensure we don't add duplicates
+  echo "$gomod_dirs" | awk -F/ '{print $1}' | sort -u | while IFS= read -r dir; do
+    echo "      - \"$dir/**/*\"" >> "$dependabot_file"
+  done
+
+  echo "    schedule:" >> "$dependabot_file"
+  echo "      interval: \"daily\"" >> "$dependabot_file"
+  echo "    groups:" >> "$dependabot_file"
+  echo "      gomod-dependencies:" >> "$dependabot_file"
+  echo "        patterns:" >> "$dependabot_file"
+  echo "          - \"*\"" >> "$dependabot_file"
+fi
+
+echo "dependabot.yml has been successfully generated."


### PR DESCRIPTION
This PR updates the dependabot script to use globbing at this top level

script tested locally and outputs as:

```
# This file is auto-generated, do not manually amend.
# https://github.com/ministryofjustice/modernisation-platform-terraform-baselines/blob/main/scripts/generate-dependabot-file.sh

version: 2

updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "daily"
    groups:
      action-dependencies:
        patterns:
          - "*"
  - package-ecosystem: "terraform"
    directories:
      - "./**/*"
      - "modules/**/*"
      - "test/**/*"
    schedule:
      interval: "daily"
  - package-ecosystem: "gomod"
    directories:
      - "test/**/*"
    schedule:
      interval: "daily"
    groups:
      gomod-dependencies:
        patterns:
          - "*"
```