### PR TITLE
Resolve issues in `terraform plan` runs.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -5,7 +5,7 @@ resource "aws_iam_service_linked_role" "config" {
 
 # AWS Config: configure an S3 bucket
 module "config-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=8688bc15a08fbf5a4f4eef9b7433c5a417df8df1" # v7.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=474f27a3f9bf542a8826c76fb049cc84b5cf136f" # v8.2.1
   providers = {
     aws.bucket-replication = aws.replication-region
   }

--- a/main.tf
+++ b/main.tf
@@ -2,13 +2,9 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 module "cloudtrail" {
   source = "./modules/cloudtrail"
-  providers = {
-    aws.replication-region = aws.replication-region
-  }
   cloudtrail_kms_key               = var.cloudtrail_kms_key
   cloudtrail_bucket                = local.cloudtrail_bucket
   enable_cloudtrail_s3_mgmt_events = var.enable_cloudtrail_s3_mgmt_events
-  # replication_role_arn = module.s3-replication-role.role.arn
   tags = var.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,11 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 module "cloudtrail" {
-  source = "./modules/cloudtrail"
+  source                           = "./modules/cloudtrail"
   cloudtrail_kms_key               = var.cloudtrail_kms_key
   cloudtrail_bucket                = local.cloudtrail_bucket
   enable_cloudtrail_s3_mgmt_events = var.enable_cloudtrail_s3_mgmt_events
-  tags = var.tags
+  tags                             = var.tags
 }
 
 module "iam" {

--- a/modules/cloudtrail/main.tf
+++ b/modules/cloudtrail/main.tf
@@ -18,7 +18,7 @@ resource "aws_cloudtrail" "cloudtrail" {
   is_multi_region_trail         = true
   kms_key_id                    = var.cloudtrail_kms_key
   s3_bucket_name                = var.cloudtrail_bucket
-  sns_topic_name                = aws_sns_topic.cloudtrail.arn
+  sns_topic_name                = aws_sns_topic.cloudtrail.name
 
   dynamic "event_selector" {
     for_each = var.enable_cloudtrail_s3_mgmt_events ? [1] : []

--- a/modules/cloudtrail/versions.tf
+++ b/modules/cloudtrail/versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0"
+      source                = "hashicorp/aws"
+      version               = "~> 5.0"
       configuration_aliases = [aws.replication-region]
     }
   }

--- a/modules/cloudtrail/versions.tf
+++ b/modules/cloudtrail/versions.tf
@@ -1,9 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source                = "hashicorp/aws"
-      version               = "~> 5.0"
-      configuration_aliases = [aws.replication-region]
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/modules/cloudtrail/versions.tf
+++ b/modules/cloudtrail/versions.tf
@@ -3,7 +3,7 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 5.0"
-      #configuration_aliases = [aws.replication-region]
+      configuration_aliases = [aws.replication-region]
     }
   }
   required_version = ">= 1.0.1"

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,6 +1,7 @@
 module github.com/ministryofjustice/modernisation-platform-terraform-baselines
 
-go 1.23
+go 1.23.0
+
 toolchain go1.24.1
 
 require (


### PR DESCRIPTION
This PR is tracked upstream by #[9384](https://github.com/ministryofjustice/modernisation-platform/issues/9384) in the modernisation-platform repository.

This PR resolves the following:
* Removes unused provider alias from CloudTrail module
* Resolves CloudTrail SNS topic name being constantly overwritten by ARN in plan
* Bump to latest version of s3 bucket module

NB. There remains an error with `aws_s3_bucket_lifecycle_configuration` which does not appear in `5.89.0` of the AWS provider and is tracked by this issue: https://github.com/hashicorp/terraform-provider-aws/issues/42274.