### PR TITLE
Add blank prefix to lifecycle rule

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -17,8 +17,8 @@ module "config-bucket" {
     {
       id      = "main"
       enabled = "Enabled"
-
-      tags = {
+      prefix  = ""
+      tags    = {
         rule      = "log"
         autoclean = "true"
       }

--- a/config.tf
+++ b/config.tf
@@ -18,7 +18,7 @@ module "config-bucket" {
       id      = "main"
       enabled = "Enabled"
       prefix  = ""
-      tags    = {
+      tags = {
         rule      = "log"
         autoclean = "true"
       }


### PR DESCRIPTION
This PR is tracked upstream by #[9384](https://github.com/ministryofjustice/modernisation-platform/issues/9384) in the modernisation-platform repository.

As the code which creates a config bucket supplies its own lifecycle rule it also needs to supply a prefix value. This resolves the following error message:

```
No attribute specified when one (and only one) of
│ [rule[0].filter[0].prefix.<.object_size_greater_than,rule[0].filter[0].prefix.
<.object_size_less_than,rule[0].filter[0].prefix.<.and,rule[0].filter[0].prefix.<.tag] is required
```