### PR TITLE
This resets the root account usage alarm to use the standard sns topic.

### DIFF
--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -171,7 +171,7 @@ resource "aws_cloudwatch_log_metric_filter" "root-account-usage" {
 resource "aws_cloudwatch_metric_alarm" "root-account-usage" {
   alarm_name        = var.root_account_usage_alarm_name
   alarm_description = "Monitors for root account usage."
-  alarm_actions     = [aws_sns_topic.high-priority-alarms.arn]
+  alarm_actions     = [aws_sns_topic.securityhub-alarms.arn]
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"


### PR DESCRIPTION
This resets the root account usage alarm to use the securityhub-alarms sns topic. This will allow the new high-priority-alarms topic to be created across all accounts that implement baselines without re-routing the alerts for that alarm.