### PR TITLE
issue/9831 - PagerDuty Integration for High Priority Alarms.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,10 +40,7 @@ module "securityhub-alarms" {
   admin_role_usage_metric_filter_name                 = "admin-role-usage-${local.workspace_name}"
   orgaccess_role_usage_metric_filter_name             = "orgaccess-role-usage-${local.workspace_name}"
 
-  high_priority_pagerduty_key                         = var.high_priority_pagerduty_integration_key
+  high_priority_pagerduty_key = var.high_priority_pagerduty_integration_key
 
   tags = var.tags
 }
-
-
-

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,8 @@ module "securityhub-alarms" {
   admin_role_usage_metric_filter_name                 = "admin-role-usage-${local.workspace_name}"
   orgaccess_role_usage_metric_filter_name             = "orgaccess-role-usage-${local.workspace_name}"
 
+  high_priority_pagerduty_key                         = var.high_priority_pagerduty_integration_key
+
   tags = var.tags
 }
 

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -171,7 +171,7 @@ resource "aws_cloudwatch_log_metric_filter" "root-account-usage" {
 resource "aws_cloudwatch_metric_alarm" "root-account-usage" {
   alarm_name        = var.root_account_usage_alarm_name
   alarm_description = "Monitors for root account usage."
-  alarm_actions     = [aws_sns_topic.securityhub-alarms.arn]
+  alarm_actions     = [aws_sns_topic.high-priority-alarms.arn]
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -690,4 +690,13 @@ resource "aws_cloudwatch_metric_alarm" "orgaccess_role_usage" {
   treat_missing_data  = "notBreaching"
 
   tags = var.tags
+}
+
+# High Priority PagerDuty Notifications
+# This adds pagerduty ingration for alarms alerting to the high-priority slack channel.
+
+module "pagerduty_high_priority_alerts" {
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
+  sns_topics                = compact([aws_sns_topic.high_priority_topic.name])
+  pagerduty_integration_key = var.high_priority_pagerduty_key
 }

--- a/modules/securityhub-alarms/variables.tf
+++ b/modules/securityhub-alarms/variables.tf
@@ -218,3 +218,8 @@ variable "orgaccess_role_usage_alarm_name" {
   default = "orgaccess-role-usage"
   type    = string
 }
+
+variable "high_priority_pagerduty_key" {
+  default = ""
+  type    = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -83,3 +83,9 @@ variable "pagerduty_integration_key" {
   description = "A PagerDuty integration key to pass into a PagerDuty integration"
   type        = string
 }
+
+variable "high_priority_pagerduty_integration_key" {
+  default     = ""
+  description = "A PagerDuty integration key for high priority alerts"
+  type        = string
+}


### PR DESCRIPTION
This adds to baselines the pagerduty integration for routing alerts sent via the high-priority-alarms sns topic to that slack channel without invoking on-call procedures. Amends the root account usage alarm to use that topic.