### PR TITLE
Issue/9831 dependencies

### DIFF
--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -696,7 +696,7 @@ resource "aws_cloudwatch_metric_alarm" "orgaccess_role_usage" {
 # This adds pagerduty ingration for alarms alerting to the high-priority slack channel.
 
 module "pagerduty_high_priority_alerts" {
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
   depends_on = [
     aws_sns_topic.high_priority_alarms_topic
   ]

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -87,7 +87,7 @@ resource "aws_sns_topic" "securityhub-alarms" {
 }
 
 # SNS topic for high-priority rememdiation
-resource "aws_sns_topic" "high_priority_alarms" {
+resource "aws_sns_topic" "high_priority_alarms_topic" {
   name              = var.high_priority_sns_topic_name
   kms_master_key_id = aws_kms_key.securityhub-alarms.arn
   tags              = var.tags
@@ -171,7 +171,7 @@ resource "aws_cloudwatch_log_metric_filter" "root-account-usage" {
 resource "aws_cloudwatch_metric_alarm" "root-account-usage" {
   alarm_name        = var.root_account_usage_alarm_name
   alarm_description = "Monitors for root account usage."
-  alarm_actions     = [aws_sns_topic.high_priority_alarms.arn]
+  alarm_actions     = [aws_sns_topic.high_priority_alarms_topic.arn]
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -698,8 +698,8 @@ resource "aws_cloudwatch_metric_alarm" "orgaccess_role_usage" {
 module "pagerduty_high_priority_alerts" {
   source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
   depends_on = [
-    aws_sns_topic.high_priority_alarms
+    aws_sns_topic.high_priority_alarms_topic
   ]
-  sns_topics                = compact([aws_sns_topic.high_priority_alarms.name])
+  sns_topics                = compact([aws_sns_topic.high_priority_alarms_topic.name])
   pagerduty_integration_key = var.high_priority_pagerduty_key
 }

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -697,6 +697,9 @@ resource "aws_cloudwatch_metric_alarm" "orgaccess_role_usage" {
 
 module "pagerduty_high_priority_alerts" {
   source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
+  depends_on = [
+    aws_sns_topic.high_priority_alarms
+  ]
   sns_topics                = compact([aws_sns_topic.high_priority_alarms.name])
   pagerduty_integration_key = var.high_priority_pagerduty_key
 }

--- a/modules/securityhub-alarms/variables.tf
+++ b/modules/securityhub-alarms/variables.tf
@@ -20,7 +20,7 @@ variable "securityhub_alarms_sns_topic_name" {
 }
 
 variable "high_priority_sns_topic_name" {
-  default = "high-priority-alarms"
+  default = "high-priority-alarms-topic"
   type    = string
 }
 


### PR DESCRIPTION
This PR renames both the terraform & resource name of the high-priority SNS topic to properly differentiate from the existing topic resource that was being replaced in an earlier commit. 

This deployment has been tested in sprinkler by putting that account's baselines deployment back to 7.13.5 & then applying this commit. The test worked successfully.

See https://github.com/ministryofjustice/modernisation-platform/actions/runs/14908481330/job/41876713044?pr=9984 for the apply details.
