### PR TITLE
Notify on backup jobs completed with warnings as well as failures

### DIFF
--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -195,7 +195,10 @@ resource "aws_sns_topic" "backup_failure_topic" {
 
 # Attaches the SNS topic to the backup vault to subscribe for notifications
 resource "aws_backup_vault_notifications" "aws_backup_vault_notifications" {
-  backup_vault_events = ["BACKUP_JOB_FAILED"]
-  backup_vault_name   = aws_backup_vault.default.name
-  sns_topic_arn       = aws_sns_topic.backup_failure_topic.arn
+  backup_vault_events = [
+    "BACKUP_JOB_FAILED",
+    "BACKUP_JOB_COMPLETED_WITH_WARNINGS"
+  ]
+  backup_vault_name = aws_backup_vault.default.name
+  sns_topic_arn     = aws_sns_topic.backup_failure_topic.arn
 }


### PR DESCRIPTION
This PR updates the aws_backup_vault_notifications resource to send notifications for both failed backup jobs and jobs that complete with warnings, ensuring better visibility of potential issues.