### PR TITLE
Centralise AWS Config S3 Bucket Reference

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -193,7 +193,7 @@ module "config-ap-northeast-1" {
     aws = aws.ap-northeast-1
   }
   iam_role_arn       = aws_iam_service_linked_role.config.arn
-  s3_bucket_id       = module.config-bucket.bucket.id
+  s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
   home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
@@ -214,7 +214,7 @@ module "config-ap-northeast-2" {
     aws = aws.ap-northeast-2
   }
   iam_role_arn       = aws_iam_service_linked_role.config.arn
-  s3_bucket_id       = module.config-bucket.bucket.id
+  s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
   home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
@@ -235,7 +235,7 @@ module "config-ap-south-1" {
     aws = aws.ap-south-1
   }
   iam_role_arn       = aws_iam_service_linked_role.config.arn
-  s3_bucket_id       = module.config-bucket.bucket.id
+  s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
   home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
@@ -256,7 +256,7 @@ module "config-ap-southeast-1" {
     aws = aws.ap-southeast-1
   }
   iam_role_arn       = aws_iam_service_linked_role.config.arn
-  s3_bucket_id       = module.config-bucket.bucket.id
+  s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
   home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
@@ -277,7 +277,7 @@ module "config-ap-southeast-2" {
     aws = aws.ap-southeast-2
   }
   iam_role_arn       = aws_iam_service_linked_role.config.arn
-  s3_bucket_id       = module.config-bucket.bucket.id
+  s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
   home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
@@ -298,7 +298,7 @@ module "config-ca-central-1" {
     aws = aws.ca-central-1
   }
   iam_role_arn       = aws_iam_service_linked_role.config.arn
-  s3_bucket_id       = module.config-bucket.bucket.id
+  s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
   home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
@@ -319,7 +319,7 @@ module "config-eu-central-1" {
     aws = aws.eu-central-1
   }
   iam_role_arn       = aws_iam_service_linked_role.config.arn
-  s3_bucket_id       = module.config-bucket.bucket.id
+  s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
   home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
@@ -340,7 +340,7 @@ module "config-eu-north-1" {
     aws = aws.eu-north-1
   }
   iam_role_arn       = aws_iam_service_linked_role.config.arn
-  s3_bucket_id       = module.config-bucket.bucket.id
+  s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
   home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
@@ -361,7 +361,7 @@ module "config-eu-west-1" {
     aws = aws.eu-west-1
   }
   iam_role_arn       = aws_iam_service_linked_role.config.arn
-  s3_bucket_id       = module.config-bucket.bucket.id
+  s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
   home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
@@ -382,7 +382,7 @@ module "config-eu-west-2" {
     aws = aws.eu-west-2
   }
   iam_role_arn       = aws_iam_service_linked_role.config.arn
-  s3_bucket_id       = module.config-bucket.bucket.id
+  s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
   home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
@@ -403,7 +403,7 @@ module "config-eu-west-3" {
     aws = aws.eu-west-3
   }
   iam_role_arn       = aws_iam_service_linked_role.config.arn
-  s3_bucket_id       = module.config-bucket.bucket.id
+  s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
   home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
@@ -424,7 +424,7 @@ module "config-sa-east-1" {
     aws = aws.sa-east-1
   }
   iam_role_arn       = aws_iam_service_linked_role.config.arn
-  s3_bucket_id       = module.config-bucket.bucket.id
+  s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
   home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
@@ -445,7 +445,7 @@ module "config-us-east-1" {
     aws = aws.us-east-1
   }
   iam_role_arn       = aws_iam_service_linked_role.config.arn
-  s3_bucket_id       = module.config-bucket.bucket.id
+  s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
   home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
@@ -466,7 +466,7 @@ module "config-us-east-2" {
     aws = aws.us-east-2
   }
   iam_role_arn       = aws_iam_service_linked_role.config.arn
-  s3_bucket_id       = module.config-bucket.bucket.id
+  s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
   home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
@@ -487,7 +487,7 @@ module "config-us-west-1" {
     aws = aws.us-west-1
   }
   iam_role_arn       = aws_iam_service_linked_role.config.arn
-  s3_bucket_id       = module.config-bucket.bucket.id
+  s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
   home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id
@@ -508,7 +508,7 @@ module "config-us-west-2" {
     aws = aws.us-west-2
   }
   iam_role_arn       = aws_iam_service_linked_role.config.arn
-  s3_bucket_id       = module.config-bucket.bucket.id
+  s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
   home_region        = data.aws_region.current.name
   current_account_id = var.current_account_id

--- a/locals.tf
+++ b/locals.tf
@@ -2,5 +2,6 @@ locals {
   enabled           = toset(["enabled"])
   not_enabled       = toset([])
   cloudtrail_bucket = "modernisation-platform-logs-cloudtrail"
+  config_bucket     = "modernisation-platform-logs-config"
   workspace_name    = terraform.workspace == "default" ? "modernisation-platform" : terraform.workspace
 }


### PR DESCRIPTION
This PR updates the config to send logs to the central bucket (core-logging) instead of using a separate bucket in each account. [#912](https://github.com/ministryofjustice/modernisation-platform/issues/912)

