### PR TITLE
Adds tags to applicable resources in securityhub module and to config sns key

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -135,6 +135,7 @@ resource "aws_kms_key" "config-sns-key" {
   description                        = "KMS key for AWS Config SNS topic"
   multi_region                       = true
   policy                             = data.aws_iam_policy_document.config-sns-key-policy.json
+  tags                               = var.tags
 }
 
 resource "aws_kms_alias" "config-sns-key-alias" {

--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -91,6 +91,7 @@ resource "aws_cloudwatch_event_rule" "sechub_high_and_critical_findings" {
       }
     }
   })
+  tags = var.tags
 }
 
 # When eventbridge rule is triggered send findings to SNS topic
@@ -106,6 +107,7 @@ resource "aws_sns_topic" "sechub_findings_sns_topic" {
   count             = var.enable_securityhub_alerts ? 1 : 0
   name              = var.sechub_sns_topic_name
   kms_master_key_id = length(aws_kms_key.sns_kms_key) > 0 ? aws_kms_key.sns_kms_key[0].id : null
+  tags              = var.tags
 }
 resource "aws_sns_topic_policy" "sechub_findings_sns_topic" {
   count  = var.enable_securityhub_alerts ? 1 : 0
@@ -172,6 +174,7 @@ resource "aws_kms_key" "sns_kms_key" {
   description                        = "KMS key for SNS topic encryption"
   enable_key_rotation                = true
   policy                             = data.aws_iam_policy_document.sns_kms.json
+  tags                               = var.tags
 }
 
 resource "aws_kms_alias" "sns_kms_alias" {

--- a/modules/securityhub/variables.tf
+++ b/modules/securityhub/variables.tf
@@ -27,3 +27,8 @@ variable "pagerduty_integration_key" {
   description = "A PagerDuty integration key to pass into a PagerDuty integration"
   type        = string
 }
+variable "tags" {
+  default     = {}
+  description = "Tags to apply to resources, where applicable"
+  type        = map(any)
+}


### PR DESCRIPTION
This PR addresses issue raised here: [10313](https://github.com/ministryofjustice/modernisation-platform/issues/10313).

It fixes the issue where resources were missing tags, making it easier to track and manage them in AWS. 