### PR TITLE
Update aws provider to v6

### DIFF
--- a/modules/access-analyzer/versions.tf
+++ b/modules/access-analyzer/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/modules/backup/versions.tf
+++ b/modules/backup/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/modules/cloudtrail/versions.tf
+++ b/modules/cloudtrail/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/modules/config/versions.tf
+++ b/modules/config/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/modules/ebs/versions.tf
+++ b/modules/ebs/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/modules/guardduty/versions.tf
+++ b/modules/guardduty/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/modules/iam/versions.tf
+++ b/modules/iam/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/modules/imdsv2/versions.tf
+++ b/modules/imdsv2/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -696,7 +696,7 @@ resource "aws_cloudwatch_metric_alarm" "orgaccess_role_usage" {
 # This adds pagerduty ingration for alarms alerting to the high-priority slack channel.
 
 module "pagerduty_high_priority_alerts" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=d88bd90d490268896670a898edfaba24bba2f8ab" # v3.0.0
   depends_on = [
     aws_sns_topic.high_priority_alarms_topic
   ]

--- a/modules/securityhub-alarms/versions.tf
+++ b/modules/securityhub-alarms/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -237,7 +237,7 @@ module "pagerduty_alerts_securityhub" {
   depends_on = [
     aws_sns_topic.sechub_findings_sns_topic
   ]
-  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=0179859e6fafc567843cd55c0b05d325d5012dc4" # v2.0.0
+  source                    = "github.com/ministryofjustice/modernisation-platform-terraform-pagerduty-integration?ref=d88bd90d490268896670a898edfaba24bba2f8ab" # v3.0.0
   sns_topics                = [aws_sns_topic.sechub_findings_sns_topic[0].name]
   pagerduty_integration_key = var.pagerduty_integration_key
 }

--- a/modules/securityhub/versions.tf
+++ b/modules/securityhub/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/modules/support/versions.tf
+++ b/modules/support/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.0.1"

--- a/test/backup-test/versions.tf
+++ b/test/backup-test/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/test/cloudtrail-test/versions.tf
+++ b/test/cloudtrail-test/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/test/securityhub-alarms-test/versions.tf
+++ b/test/securityhub-alarms-test/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/test/securityhub-test/versions.tf
+++ b/test/securityhub-test/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/test/support-test/versions.tf
+++ b/test/support-test/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.0"
+      version = "~> 6.0"
       source  = "hashicorp/aws"
     }
     http = {

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
       configuration_aliases = [
         aws.replication-region,
         aws.ap-northeast-1,


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform/issues/10509

## Changes
Updated aws TF provider to `~> 6.0`

Updated `modernisation-platform-terraform-pagerduty-integration` module to v3 for compatibility