### PR TITLE
Update config s3 bucket to v6 aws provider compatibility

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -5,7 +5,7 @@ resource "aws_iam_service_linked_role" "config" {
 
 # AWS Config: configure an S3 bucket
 module "config-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=474f27a3f9bf542a8826c76fb049cc84b5cf136f" # v8.2.1
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
   providers = {
     aws.bucket-replication = aws.replication-region
   }


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform/issues/10509

## Changes
I've updated the config bucket to use v9 of the s3 bucket module which is the latest release compatible with v6 of the aws provider.