### PR TITLE
Replaces deprecated name attribute with region

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -196,7 +196,7 @@ module "config-ap-northeast-1" {
   iam_role_arn       = aws_iam_service_linked_role.config.arn
   s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
-  home_region        = data.aws_region.current.name
+  home_region        = data.aws_region.current.region
   current_account_id = var.current_account_id
   sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
@@ -217,7 +217,7 @@ module "config-ap-northeast-2" {
   iam_role_arn       = aws_iam_service_linked_role.config.arn
   s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
-  home_region        = data.aws_region.current.name
+  home_region        = data.aws_region.current.region
   current_account_id = var.current_account_id
   sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
@@ -238,7 +238,7 @@ module "config-ap-south-1" {
   iam_role_arn       = aws_iam_service_linked_role.config.arn
   s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
-  home_region        = data.aws_region.current.name
+  home_region        = data.aws_region.current.region
   current_account_id = var.current_account_id
   sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
@@ -259,7 +259,7 @@ module "config-ap-southeast-1" {
   iam_role_arn       = aws_iam_service_linked_role.config.arn
   s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
-  home_region        = data.aws_region.current.name
+  home_region        = data.aws_region.current.region
   current_account_id = var.current_account_id
   sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
@@ -280,7 +280,7 @@ module "config-ap-southeast-2" {
   iam_role_arn       = aws_iam_service_linked_role.config.arn
   s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
-  home_region        = data.aws_region.current.name
+  home_region        = data.aws_region.current.region
   current_account_id = var.current_account_id
   sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
@@ -301,7 +301,7 @@ module "config-ca-central-1" {
   iam_role_arn       = aws_iam_service_linked_role.config.arn
   s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
-  home_region        = data.aws_region.current.name
+  home_region        = data.aws_region.current.region
   current_account_id = var.current_account_id
   sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
@@ -322,7 +322,7 @@ module "config-eu-central-1" {
   iam_role_arn       = aws_iam_service_linked_role.config.arn
   s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
-  home_region        = data.aws_region.current.name
+  home_region        = data.aws_region.current.region
   current_account_id = var.current_account_id
   sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
@@ -343,7 +343,7 @@ module "config-eu-north-1" {
   iam_role_arn       = aws_iam_service_linked_role.config.arn
   s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
-  home_region        = data.aws_region.current.name
+  home_region        = data.aws_region.current.region
   current_account_id = var.current_account_id
   sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
@@ -364,7 +364,7 @@ module "config-eu-west-1" {
   iam_role_arn       = aws_iam_service_linked_role.config.arn
   s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
-  home_region        = data.aws_region.current.name
+  home_region        = data.aws_region.current.region
   current_account_id = var.current_account_id
   sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
@@ -385,7 +385,7 @@ module "config-eu-west-2" {
   iam_role_arn       = aws_iam_service_linked_role.config.arn
   s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
-  home_region        = data.aws_region.current.name
+  home_region        = data.aws_region.current.region
   current_account_id = var.current_account_id
   sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
@@ -406,7 +406,7 @@ module "config-eu-west-3" {
   iam_role_arn       = aws_iam_service_linked_role.config.arn
   s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
-  home_region        = data.aws_region.current.name
+  home_region        = data.aws_region.current.region
   current_account_id = var.current_account_id
   sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
@@ -427,7 +427,7 @@ module "config-sa-east-1" {
   iam_role_arn       = aws_iam_service_linked_role.config.arn
   s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
-  home_region        = data.aws_region.current.name
+  home_region        = data.aws_region.current.region
   current_account_id = var.current_account_id
   sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
@@ -448,7 +448,7 @@ module "config-us-east-1" {
   iam_role_arn       = aws_iam_service_linked_role.config.arn
   s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
-  home_region        = data.aws_region.current.name
+  home_region        = data.aws_region.current.region
   current_account_id = var.current_account_id
   sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
@@ -469,7 +469,7 @@ module "config-us-east-2" {
   iam_role_arn       = aws_iam_service_linked_role.config.arn
   s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
-  home_region        = data.aws_region.current.name
+  home_region        = data.aws_region.current.region
   current_account_id = var.current_account_id
   sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
@@ -490,7 +490,7 @@ module "config-us-west-1" {
   iam_role_arn       = aws_iam_service_linked_role.config.arn
   s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
-  home_region        = data.aws_region.current.name
+  home_region        = data.aws_region.current.region
   current_account_id = var.current_account_id
   sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {
@@ -511,7 +511,7 @@ module "config-us-west-2" {
   iam_role_arn       = aws_iam_service_linked_role.config.arn
   s3_bucket_id       = local.config_bucket
   root_account_id    = var.root_account_id
-  home_region        = data.aws_region.current.name
+  home_region        = data.aws_region.current.region
   current_account_id = var.current_account_id
   sns_topic_key      = aws_kms_key.config-sns-key.key_id
   cloudtrail = {

--- a/modules/cloudtrail/main.tf
+++ b/modules/cloudtrail/main.tf
@@ -2,7 +2,7 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 locals {
-  iam_policy_logs_arn = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*"
+  iam_policy_logs_arn = "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.cloudtrail.name}:log-stream:*"
 }
 
 # Enable CloudTrail

--- a/modules/config/main.tf
+++ b/modules/config/main.tf
@@ -91,7 +91,7 @@ data "aws_iam_policy_document" "config-sns-policy" {
 
 # Configure AWS Config rules
 resource "aws_config_config_rule" "access-keys-rotated" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name                        = "access-keys-rotated"
   maximum_execution_frequency = "TwentyFour_Hours"
@@ -111,7 +111,7 @@ resource "aws_config_config_rule" "access-keys-rotated" {
 }
 
 resource "aws_config_config_rule" "account-part-of-organizations" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name                        = "account-part-of-organizations"
   maximum_execution_frequency = "TwentyFour_Hours"
@@ -131,7 +131,7 @@ resource "aws_config_config_rule" "account-part-of-organizations" {
 }
 
 resource "aws_config_config_rule" "cloud-trail-cloud-watch-logs-enabled" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name                        = "cloud-trail-cloud-watch-logs-enabled"
   maximum_execution_frequency = "TwentyFour_Hours"
@@ -147,7 +147,7 @@ resource "aws_config_config_rule" "cloud-trail-cloud-watch-logs-enabled" {
 }
 
 resource "aws_config_config_rule" "cloud-trail-encryption-enabled" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name                        = "cloud-trail-encryption-enabled"
   maximum_execution_frequency = "TwentyFour_Hours"
@@ -163,7 +163,7 @@ resource "aws_config_config_rule" "cloud-trail-encryption-enabled" {
 }
 
 resource "aws_config_config_rule" "cloud-trail-log-file-validation-enabled" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name                        = "cloud-trail-log-file-validation-enabled"
   maximum_execution_frequency = "TwentyFour_Hours"
@@ -179,7 +179,7 @@ resource "aws_config_config_rule" "cloud-trail-log-file-validation-enabled" {
 }
 
 resource "aws_config_config_rule" "cloudtrail-enabled" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name                        = "cloudtrail-enabled"
   maximum_execution_frequency = "TwentyFour_Hours"
@@ -201,7 +201,7 @@ resource "aws_config_config_rule" "cloudtrail-enabled" {
 }
 
 resource "aws_config_config_rule" "cloudtrail-s3-dataevents-enabled" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name                        = "cloudtrail-s3-dataevents-enabled"
   maximum_execution_frequency = "TwentyFour_Hours"
@@ -217,7 +217,7 @@ resource "aws_config_config_rule" "cloudtrail-s3-dataevents-enabled" {
 }
 
 resource "aws_config_config_rule" "cloudtrail-security-trail-enabled" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name                        = "cloudtrail-security-trail-enabled"
   maximum_execution_frequency = "TwentyFour_Hours"
@@ -233,7 +233,7 @@ resource "aws_config_config_rule" "cloudtrail-security-trail-enabled" {
 }
 
 resource "aws_config_config_rule" "iam-group-has-users-check" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name = "iam-group-has-users-check"
 
@@ -248,7 +248,7 @@ resource "aws_config_config_rule" "iam-group-has-users-check" {
 }
 
 resource "aws_config_config_rule" "iam-no-inline-policy-check" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name = "iam-no-inline-policy-check"
 
@@ -263,7 +263,7 @@ resource "aws_config_config_rule" "iam-no-inline-policy-check" {
 }
 
 resource "aws_config_config_rule" "iam-password-policy" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name                        = "iam-password-policy"
   maximum_execution_frequency = "TwentyFour_Hours"
@@ -288,7 +288,7 @@ resource "aws_config_config_rule" "iam-password-policy" {
 }
 
 resource "aws_config_config_rule" "iam-root-access-key-check" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name                        = "iam-root-access-key-check"
   maximum_execution_frequency = "TwentyFour_Hours"
@@ -304,7 +304,7 @@ resource "aws_config_config_rule" "iam-root-access-key-check" {
 }
 
 resource "aws_config_config_rule" "iam-user-mfa-enabled" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name                        = "iam-user-mfa-enabled"
   maximum_execution_frequency = "TwentyFour_Hours"
@@ -320,7 +320,7 @@ resource "aws_config_config_rule" "iam-user-mfa-enabled" {
 }
 
 resource "aws_config_config_rule" "iam-user-unused-credentials-check" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name                        = "iam-user-unused-credentials-check"
   maximum_execution_frequency = "TwentyFour_Hours"
@@ -340,7 +340,7 @@ resource "aws_config_config_rule" "iam-user-unused-credentials-check" {
 }
 
 resource "aws_config_config_rule" "mfa-enabled-for-iam-console-access" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name                        = "mfa-enabled-for-iam-console-access"
   maximum_execution_frequency = "TwentyFour_Hours"
@@ -356,7 +356,7 @@ resource "aws_config_config_rule" "mfa-enabled-for-iam-console-access" {
 }
 
 resource "aws_config_config_rule" "multi-region-cloudtrail-enabled" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name                        = "multi-region-cloudtrail-enabled"
   maximum_execution_frequency = "TwentyFour_Hours"
@@ -400,7 +400,7 @@ resource "aws_config_config_rule" "required-tags" {
 }
 
 resource "aws_config_config_rule" "root-account-mfa-enabled" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name                        = "root-account-mfa-enabled"
   maximum_execution_frequency = "TwentyFour_Hours"
@@ -416,7 +416,7 @@ resource "aws_config_config_rule" "root-account-mfa-enabled" {
 }
 
 resource "aws_config_config_rule" "s3-account-level-public-access-blocks" {
-  count = (var.home_region == data.aws_region.current.name) ? 1 : 0
+  count = (var.home_region == data.aws_region.current.region) ? 1 : 0
 
   name = "s3-account-level-public-access-blocks"
 

--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -6,7 +6,7 @@ data "aws_caller_identity" "current" {}
 
 # Enable Standard: AWS Foundational Security Best Practices
 resource "aws_securityhub_standards_subscription" "aws-foundational" {
-  standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-foundational-security-best-practices/v/1.0.0"
+  standards_arn = "arn:aws:securityhub:${data.aws_region.current.region}::standards/aws-foundational-security-best-practices/v/1.0.0"
 }
 
 # Enable Standard: CIS AWS Foundations
@@ -16,48 +16,48 @@ resource "aws_securityhub_standards_subscription" "cis" {
 
 # Enable Standard: PCI DSS v3.2.1
 resource "aws_securityhub_standards_subscription" "pci" {
-  standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/pci-dss/v/3.2.1"
+  standards_arn = "arn:aws:securityhub:${data.aws_region.current.region}::standards/pci-dss/v/3.2.1"
 }
 
 # Disabled standard controls - controls that we are not using as we have other mitigating factors in place
 # Disable security hub control, security hub currently doesn't cater for SSO log in with MFA from the SSO provider
 resource "aws_securityhub_standards_control" "cis_disable_mfa_metric_and_alarm" {
-  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/cis-aws-foundations-benchmark/v/1.2.0/3.2"
+  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:control/cis-aws-foundations-benchmark/v/1.2.0/3.2"
   control_status        = "DISABLED"
   disabled_reason       = "MFA from single sign on not supported currently"
   depends_on            = [aws_securityhub_standards_subscription.cis]
 }
 
 resource "aws_securityhub_standards_control" "cis_disable_ensure_hardware_mfa_for_root" {
-  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/cis-aws-foundations-benchmark/v/1.2.0/1.14"
+  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:control/cis-aws-foundations-benchmark/v/1.2.0/1.14"
   control_status        = "DISABLED"
   disabled_reason       = "Root login actions prevented with SCPs"
   depends_on            = [aws_securityhub_standards_subscription.cis]
 }
 
 resource "aws_securityhub_standards_control" "cis_disable_ensure_mfa_for_root" {
-  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/cis-aws-foundations-benchmark/v/1.2.0/1.13"
+  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:control/cis-aws-foundations-benchmark/v/1.2.0/1.13"
   control_status        = "DISABLED"
   disabled_reason       = "Root login actions prevented with SCPs"
   depends_on            = [aws_securityhub_standards_subscription.cis]
 }
 
 resource "aws_securityhub_standards_control" "aws_disable_ensure_hardware_mfa_for_root" {
-  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/aws-foundational-security-best-practices/v/1.0.0/IAM.6"
+  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:control/aws-foundational-security-best-practices/v/1.0.0/IAM.6"
   control_status        = "DISABLED"
   disabled_reason       = "Root login actions prevented with SCPs"
   depends_on            = [aws_securityhub_standards_subscription.aws-foundational]
 }
 
 resource "aws_securityhub_standards_control" "pci_disable_ensure_hardware_mfa_for_root" {
-  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/pci-dss/v/3.2.1/PCI.IAM.4"
+  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:control/pci-dss/v/3.2.1/PCI.IAM.4"
   control_status        = "DISABLED"
   disabled_reason       = "Root login actions prevented with SCPs"
   depends_on            = [aws_securityhub_standards_subscription.pci]
 }
 
 resource "aws_securityhub_standards_control" "pci_disable_ensure_mfa_for_root" {
-  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:control/pci-dss/v/3.2.1/PCI.IAM.5"
+  standards_control_arn = "arn:aws:securityhub:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:control/pci-dss/v/3.2.1/PCI.IAM.5"
   control_status        = "DISABLED"
   disabled_reason       = "Root login actions prevented with SCPs"
   depends_on            = [aws_securityhub_standards_subscription.pci]


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform/issues/10509

## Changes

Fixes deprecation e.g.

```
Warning: Deprecated attribute

  on .terraform/modules/baselines-modernisation-platform/config.tf line 199, in module "config-ap-northeast-1":
 199:   home_region        = data.aws_region.current.name

The attribute "name" is deprecated. Refer to the provider documentation for
details.
```