### PR TITLE
Removes the now redundant module variable enable_securityhub_alerts

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -67,12 +67,6 @@ variable "enabled_imdsv2_regions" {
   type        = list(string)
 }
 
-variable "enable_securityhub_alerts" {
-  default     = false
-  description = "Flag to indicate if alerting resources should be created in the region"
-  type        = bool
-}
-
 variable "reduced_preprod_backup_retention" {
   description = "AWS Backup variable, if true, pre prod only retains 7 days of backups"
   type        = bool


### PR DESCRIPTION
Removes a module variable that was used to determine whether alerts to slack via pagerduty would be created for SecurityHub critical rule breaches.