### PR TITLE
Add lifecycle ignore_changes for SSM service setting_id

### DIFF
--- a/modules/ssm/main.tf
+++ b/modules/ssm/main.tf
@@ -1,4 +1,7 @@
 resource "aws_ssm_service_setting" "disable_public_sharing" {
   setting_id    = "/ssm/documents/console/public-sharing-permission"
   setting_value = "Disable"
+    lifecycle {
+    ignore_changes = [setting_id]
+  }
 }


### PR DESCRIPTION
Spotted a bug where the “Block public sharing” setting in some accounts flipped from On to Off due to a mismatch in how older AWS provider versions interpret the setting ID, so I'm adding an ignore_changes lifecycle rule as a temporary fix until accounts all use aws provider v.6.6 or later where this issue is fixed. 