### PR TITLE
Draft PR to disable specific cloudtrail readonly events for selected s3 buckets in specific accounts.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,13 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 module "cloudtrail" {
-  source                           = "./modules/cloudtrail"
-  cloudtrail_kms_key               = var.cloudtrail_kms_key
-  cloudtrail_bucket                = local.cloudtrail_bucket
-  enable_cloudtrail_s3_mgmt_events = var.enable_cloudtrail_s3_mgmt_events
-  tags                             = var.tags
+  source                                         = "./modules/cloudtrail"
+  cloudtrail_kms_key                             = var.cloudtrail_kms_key
+  cloudtrail_bucket                              = local.cloudtrail_bucket
+  enable_cloudtrail_s3_mgmt_events               = var.enable_cloudtrail_s3_mgmt_events
+  enable_cloudtrail_limit_readonly_bucket_events = var.enable_cloudtrail_limit_readonly_bucket_events
+  cloudtrail_limit_readonly_bucket_arns          = var.cloudtrail_limit_readonly_bucket_arns
+  tags                                           = var.tags
 }
 
 module "iam" {

--- a/modules/cloudtrail/main.tf
+++ b/modules/cloudtrail/main.tf
@@ -20,9 +20,9 @@ resource "aws_cloudtrail" "cloudtrail" {
   s3_bucket_name                = var.cloudtrail_bucket
   sns_topic_name                = aws_sns_topic.cloudtrail.name
 
+  # If enable_cloudtrail_s3_mgmt_events is enabled, the below block is created
   dynamic "event_selector" {
     for_each = var.enable_cloudtrail_s3_mgmt_events ? [1] : []
-    # If enable_cloudtrail_s3_mgmt_events is enabled, the below block is created
     content {
       include_management_events = true
       read_write_type           = "All"
@@ -34,11 +34,95 @@ resource "aws_cloudtrail" "cloudtrail" {
     }
   }
 
+  # When readonly bucket limiting is disabled, use advanced selectors on the default trail as we want all management events logged regardless
+  dynamic "advanced_event_selector" {
+    for_each = var.enable_cloudtrail_s3_mgmt_events && var.enable_cloudtrail_limit_readonly_bucket_events ? [1] : []
+
+    content {
+      name = "all-management-events"
+
+      field_selector {
+        field  = "eventCategory"
+        equals = ["Management"]
+      }
+    }
+  }
+
+  # Enables full Data Events for S3 buckets that are not in the readonly-limited bucket list.
+  dynamic "advanced_event_selector" {
+    for_each = var.enable_cloudtrail_s3_mgmt_events && var.enable_cloudtrail_limit_readonly_bucket_events ? [1] : []
+
+    content {
+      name = "s3-data-events-all-except-listed-buckets"
+
+      field_selector {
+        field  = "eventCategory"
+        equals = ["Data"]
+      }
+
+      field_selector {
+        field  = "resources.type"
+        equals = ["AWS::S3::Object"]
+      }
+
+      field_selector {
+        field           = "resources.ARN"
+        not_starts_with = var.cloudtrail_limit_readonly_bucket_arns
+      }
+    }
+  }
+
   # wait for sns topic policy to be attached 
   depends_on = [aws_sns_topic_policy.cloudtrail]
 
   tags = var.tags
 }
+
+# Optional secondary CloudTrail for specific buckets that are to be exempted from read-only data events - Logs only write S3 data events for the ARNs in var.cloudtrail_limit_readonly_bucket_arns when var.enable_cloudtrail_limit_readonly_bucket_events is true.
+resource "aws_cloudtrail" "cloudtrail_limited" {
+  count = var.enable_cloudtrail_s3_mgmt_events && var.enable_cloudtrail_limit_readonly_bucket_events && length(var.cloudtrail_limit_readonly_bucket_arns) > 0 ? 1 : 0
+
+  name                          = "${var.cloudtrail_name}-limited"
+  cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.cloudtrail.arn}:*"
+  cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail.arn
+  enable_log_file_validation    = true
+  enable_logging                = true
+  include_global_service_events = true
+  is_multi_region_trail         = true
+  kms_key_id                    = var.cloudtrail_kms_key
+  s3_bucket_name                = var.cloudtrail_bucket
+  sns_topic_name                = aws_sns_topic.cloudtrail.name
+
+  # Sets up s3 data event logging for write-events only
+  advanced_event_selector {
+    name = "limited-buckets-writes-only"
+
+    field_selector {
+      field  = "eventCategory"
+      equals = ["Data"]
+    }
+
+    field_selector {
+      field  = "resources.type"
+      equals = ["AWS::S3::Object"]
+    }
+
+    field_selector {
+      field       = "resources.ARN"
+      starts_with = var.cloudtrail_limit_readonly_bucket_arns
+    }
+
+    field_selector {
+      field  = "readOnly"
+      equals = ["false"]
+    }
+  }
+
+  depends_on = [aws_sns_topic_policy.cloudtrail]
+
+  tags = var.tags
+}
+
 
 # IAM role for CloudTrail
 resource "aws_iam_role" "cloudtrail" {
@@ -128,3 +212,4 @@ data "aws_iam_policy_document" "cloudtrail-sns" {
     }
   }
 }
+

--- a/modules/cloudtrail/variables.tf
+++ b/modules/cloudtrail/variables.tf
@@ -19,6 +19,18 @@ variable "enable_cloudtrail_s3_mgmt_events" {
   description = "Enable CT Object-level logging, defaults to true"
 }
 
+variable "enable_cloudtrail_limit_readonly_bucket_events" {
+  type        = bool
+  default     = false
+  description = "Disables readonly events in cloudtrail for specific buckets"
+}
+
+variable "cloudtrail_limit_readonly_bucket_arns" {
+  type        = list(string)
+  default     = []
+  description = "List of S3 object ARNs (e.g. arn:aws:s3:::bucket-name/) for which only write data events should be logged when enable_cloudtrail_limit_readonly_bucket_events is true"
+}
+
 variable "retention_days" {
   default     = 400
   description = "Retention days for logs"

--- a/test/cloudtrail-test/main.tf
+++ b/test/cloudtrail-test/main.tf
@@ -8,6 +8,8 @@ module "cloudtrail-test" {
   cloudtrail_kms_key               = aws_kms_key.cloudtrail_kms_key.arn
   cloudtrail_bucket                = aws_s3_bucket.cloudtrail_s3_bucket.id
   enable_cloudtrail_s3_mgmt_events = var.enable_cloudtrail_s3_mgmt_events
+  enable_cloudtrail_limit_readonly_bucket_events = var.enable_cloudtrail_limit_readonly_bucket_events
+  cloudtrail_limit_readonly_bucket_arns          = var.cloudtrail_limit_readonly_bucket_arns
 }
 
 # Cloudtrail KMS

--- a/test/cloudtrail-test/main.tf
+++ b/test/cloudtrail-test/main.tf
@@ -1,13 +1,13 @@
 data "aws_caller_identity" "current" {}
 
 module "cloudtrail-test" {
-  depends_on                       = [aws_s3_bucket_policy.s3_cloudtrail_policy]
-  source                           = "../../modules/cloudtrail"
-  cloudtrail_name                  = var.cloudtrail_name
-  cloudtrail_policy_name           = var.cloudtrail_policy_name
-  cloudtrail_kms_key               = aws_kms_key.cloudtrail_kms_key.arn
-  cloudtrail_bucket                = aws_s3_bucket.cloudtrail_s3_bucket.id
-  enable_cloudtrail_s3_mgmt_events = var.enable_cloudtrail_s3_mgmt_events
+  depends_on                                     = [aws_s3_bucket_policy.s3_cloudtrail_policy]
+  source                                         = "../../modules/cloudtrail"
+  cloudtrail_name                                = var.cloudtrail_name
+  cloudtrail_policy_name                         = var.cloudtrail_policy_name
+  cloudtrail_kms_key                             = aws_kms_key.cloudtrail_kms_key.arn
+  cloudtrail_bucket                              = aws_s3_bucket.cloudtrail_s3_bucket.id
+  enable_cloudtrail_s3_mgmt_events               = var.enable_cloudtrail_s3_mgmt_events
   enable_cloudtrail_limit_readonly_bucket_events = var.enable_cloudtrail_limit_readonly_bucket_events
   cloudtrail_limit_readonly_bucket_arns          = var.cloudtrail_limit_readonly_bucket_arns
 }

--- a/test/cloudtrail-test/variables.tf
+++ b/test/cloudtrail-test/variables.tf
@@ -31,3 +31,15 @@ variable "cloudtrail_bucket" {
   description = "Name of centralised Cloudtrail bucket"
   type        = string
 }
+
+variable "enable_cloudtrail_limit_readonly_bucket_events" {
+  type        = bool
+  default     = false
+  description = "Disables readonly events in cloudtrail for specific buckets in tests"
+}
+
+variable "cloudtrail_limit_readonly_bucket_arns" {
+  type        = list(string)
+  default     = []
+  description = "List of S3 object ARNs for which only write data events should be logged in tests; empty by default"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,18 @@ variable "enable_cloudtrail_s3_mgmt_events" {
   description = "Enable CT Object-level logging, defaults to true"
 }
 
+variable "enable_cloudtrail_limit_readonly_bucket_events" {
+  type        = bool
+  default     = false
+  description = "Disables readonly events in cloudtrail for specific buckets"
+}
+
+variable "cloudtrail_limit_readonly_bucket_arns" {
+  type        = list(string)
+  default     = []
+  description = "List of S3 object ARNs (e.g. arn:aws:s3:::bucket-name/) for which only write data events should be logged when enable_cloudtrail_limit_readonly_bucket_events is true"
+}
+
 variable "enabled_access_analyzer_regions" {
   default     = []
   description = "Regions to enable IAM Access Analyzer in"


### PR DESCRIPTION
This PR adds the following changes:

1. Functionality to turn off cloudtrail API logging for read-only actions for specific buckets.
2. Variables to enable this in the required accounts.
