### PR TITLE
Tests fix failing metric name

### DIFF
--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -883,7 +883,7 @@ resource "aws_cloudwatch_metric_alarm" "orgaccess_role_usage" {
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.orgaccess_role_usage.id
+  metric_name         = var.orgaccess_role_usage_metric_filter_name
   namespace           = "LogMetrics"
   period              = "300"
   statistic           = "Sum"

--- a/modules/securityhub-alarms/main.tf
+++ b/modules/securityhub-alarms/main.tf
@@ -191,7 +191,7 @@ resource "aws_cloudwatch_metric_alarm" "unauthorised-api-calls" {
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.unauthorised-api-calls.id
+  metric_name         = var.unauthorised_api_calls_log_metric_filter_name
   namespace           = "LogMetrics"
   period              = "180"
   statistic           = "Sum"
@@ -221,7 +221,7 @@ resource "aws_cloudwatch_metric_alarm" "sign-in-without-mfa" {
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.sign-in-without-mfa.id
+  metric_name         = var.sign_in_without_mfa_metric_filter_name
   namespace           = "LogMetrics"
   period              = "300"
   statistic           = "Sum"
@@ -252,7 +252,7 @@ resource "aws_cloudwatch_metric_alarm" "root-account-usage" {
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.root-account-usage.id
+  metric_name         = var.root_account_usage_metric_filter_name
   namespace           = "LogMetrics"
   period              = "300"
   statistic           = "Sum"
@@ -377,7 +377,7 @@ resource "aws_cloudwatch_metric_alarm" "sign-in-failures" {
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.sign-in-failures.id
+  metric_name         = var.sign_in_failures_metric_filter_name
   namespace           = "LogMetrics"
   period              = "60"
   statistic           = "Sum"
@@ -407,7 +407,7 @@ resource "aws_cloudwatch_metric_alarm" "cmk-removal" {
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.cmk-removal.id
+  metric_name         = var.cmk_removal_metric_filter_name
   namespace           = "LogMetrics"
   period              = "300"
   statistic           = "Sum"
@@ -851,7 +851,7 @@ resource "aws_cloudwatch_metric_alarm" "admin_role_usage" {
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.admin_role_usage.id
+  metric_name         = var.admin_role_usage_metric_filter_name
   namespace           = "LogMetrics"
   period              = "300"
   statistic           = "Sum"

--- a/test/README.MD
+++ b/test/README.MD
@@ -1,0 +1,46 @@
+# Terratest Unit Tests
+
+## Initialisation
+
+On first set up of a new repository, run:
+
+```
+go mod init github.com/ministryofjustice/<repo-name>
+```
+
+Then run:
+
+```
+go mod tidy
+```
+
+# How to run the tests locally
+
+Run the tests from within the `test` directory using the `testing-test` user credentials.
+
+Get the credentials from https://moj.awsapps.com selecting the testing-test AWS account.
+
+Copy the credentials and export them by pasting them into the terminal from which you will run the tests.
+
+Next go into the testing folder and run the tests.
+
+```
+cd test
+go mod download
+go test -v
+```
+
+Upon successful run, you should see an output similar to the below
+
+```
+TestLBCreation 2024-04-26T11:30:07+01:00 logger.go:66: Destroy complete! Resources: 17 destroyed.
+TestLBCreation 2024-04-26T11:30:07+01:00 logger.go:66:
+--- PASS: TestLBCreation (283.85s)
+PASS
+ok  	github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket          284.181s
+```
+
+## References
+
+1. https://terratest.gruntwork.io/docs/getting-started/quick-start/
+2. https://github.com/ministryofjustice/modernisation-platform-terraform-loadbalancer/blob/main/.github/workflows/go-terratest.yml


### PR DESCRIPTION
**The Problem**
CloudWatch metric alarms require one of three attributes to be set:
- metric_name
- metric_query
- evaluation_criteria

The alarms had none of these properly set, which is why Terraform threw the error.

**The Root Cause**
The alarms were trying to use the metric filter's .id attribute as the metric name:
```
resource "aws_cloudwatch_metric_alarm" "unauthorised-api-calls" {
  ...
  metric_name = aws_cloudwatch_log_metric_filter.unauthorised-api-calls.id  # ❌ WRONG
  ...
}
```
The problem is that .id gives you the filter's internal ID (not the metric name). AWS CloudWatch couldn't find a metric with that ID, so it treated the metric_name as empty/invalid.

**The Solution**
Changed the alarms to reference the actual metric name from the variables:
```
resource "aws_cloudwatch_metric_alarm" "unauthorised-api-calls" {
  ...
  metric_name = var.unauthorised_api_calls_log_metric_filter_name  # ✅ CORRECT
  ...
}
```

This matches the metric name defined in the corresponding log metric filter:
```
resource "aws_cloudwatch_log_metric_filter" "unauthorised-api-calls" {
  ...
  metric_transformation {
    name      = var.unauthorised_api_calls_log_metric_filter_name  # Same name!
    namespace = "LogMetrics"
    value     = 1
  }
}
```
Now the alarm can properly find and monitor the metric created by the log metric filter. This fix was applied to all 7 failing alarms.