### PR TITLE
Set force_destroy = true on legacy config-bucket (Phase 1 of 2)

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -10,6 +10,7 @@ module "config-bucket" {
     aws.bucket-replication = aws.replication-region
   }
   replication_enabled = false
+  force_destroy       = true
   bucket_policy       = [data.aws_iam_policy_document.config-s3-policy.json]
   bucket_prefix       = "config-"
 


### PR DESCRIPTION
**What**
Adds `force_destroy = true` to the legacy `module "config-bucket"` in `config.tf`.

**Why**
AWS Config delivery has been centralised to the `modernisation-platform-logs-config` bucket in the core-logging account. The legacy per-account `config-*` buckets are no longer needed and will be removed in a follow-up PR.

Before the module can be safely removed, `force_destroy` must be set to `true`. Without this, applying the removal would fail with a `BucketNotEmpty` error because Terraform cannot destroy a non-empty S3 bucket when `force_destroy = false`.

This change is safe to apply — it updates the bucket configuration in-place with no destructive action.

Phase 2
A follow-up PR (https://github.com/ministryofjustice/modernisation-platform-terraform-baselines/pull/1045) will remove `module "config-bucket"` and its associated IAM policy document entirely. Once this PR is tagged and the module ref is bumped across all accounts, Phase 2 can be applied and Terraform will cleanly destroy the legacy `config-*` buckets.