### PR TITLE
issue93-review.

### DIFF
--- a/modules/securityhub-alarms/iam_alerts.tf
+++ b/modules/securityhub-alarms/iam_alerts.tf
@@ -256,7 +256,7 @@ resource "aws_cloudwatch_log_metric_filter" "iam_user_deletion_not_by_automation
 resource "aws_cloudwatch_metric_alarm" "iam_user_deletion_by_untrusted_role" {
   alarm_name        = var.iam_user_deletion_by_untrusted_role_alarm_name
   alarm_description = "Monitors for the deletion of IAM users other than via automation"
-  alarm_actions     = [aws_sns_topic.high_priority_alarms_topic.arn]
+  alarm_actions     = local.low_priority_excluding_suppressed_alarm_action
 
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"


### PR DESCRIPTION
Sets the iam_user_deletion_by_untrusted_role alarm to use low priority due to bug with the translation of the metric filter terraform by the cloudwatch API which has stripped the eventSource condition from the deployed filter. This needs to be investigated separately as a bug with AWS.