### PR TITLE
Add central SSM Session Manager logging baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ Set `enable_securityhub_event_forwarding = true`, `securityhub_central_event_bus
 |  enable_session_manager_logging |        Enable central Session Manager transcript logging baseline         |  bool  |  false  | no       |
 | session_manager_logging_regions | Regions where central Session Manager transcript logging is enabled | set(string) | [\"eu-west-1\", \"eu-west-2\"] | no |
 | session_manager_log_kms_key_id  | Optional KMS key ARN or ID used to encrypt central Session Manager logs   | string |  null   | no       |
-| session_manager_idle_timeout_minutes |       Idle timeout in minutes for central Session Manager shell sessions  | number |   60    | no       |
 | session_manager_logging_excluded_applications | Applications excluded because they already manage session logging through environments repo baseline preset | set(string) | see variables.tf | no |
 
 ## Outputs

--- a/locals.tf
+++ b/locals.tf
@@ -17,4 +17,16 @@ locals {
   enable_session_manager_logging = var.enable_session_manager_logging && !local.session_manager_logging_excluded_by_env_repo_opt_in
 
   session_manager_log_retention_in_days = endswith(local.workspace_name, "-production") ? 400 : 30
+
+  session_manager_idle_timeout_exceptions = {
+    ccms-ebs-development     = 60
+    laa-ccms-soa-development = 60
+    ppud-development         = 60
+  }
+
+  session_manager_idle_timeout_minutes = lookup(
+    local.session_manager_idle_timeout_exceptions,
+    local.workspace_name,
+    20
+  )
 }

--- a/modules/ssm/README.md
+++ b/modules/ssm/README.md
@@ -21,7 +21,7 @@ module "ssm" {
 | Name                                    | Description                                                                  | Type        | Default | Required |
 | --------------------------------------- | ---------------------------------------------------------------------------- | ----------- | ------- | -------- |
 | enable_session_manager_logging          | Enable Session Manager transcript logging to CloudWatch Logs.                 | bool        | false   | no       |
-| session_manager_idle_timeout_minutes    | Idle timeout in minutes for Session Manager shell sessions.                   | number      | 60      | no       |
+| session_manager_idle_timeout_minutes    | Idle timeout in minutes for Session Manager shell sessions.                   | number      | 20      | no       |
 | session_manager_log_kms_key_id          | Optional KMS key ARN or ID used to encrypt the CloudWatch log group.          | string      | null    | no       |
 | session_manager_log_retention_in_days   | Retention period in days for Session Manager transcript logs.                 | number      | 400     | no       |
 | tags                                    | Tags to apply to resources that support tagging.                              | map(any)    | {}      | no       |

--- a/modules/ssm/main.tf
+++ b/modules/ssm/main.tf
@@ -20,3 +20,42 @@ resource "aws_cloudwatch_log_group" "session_manager" {
     prevent_destroy = true
   }
 }
+
+resource "aws_ssm_document" "session_manager_run_shell" {
+  count = var.enable_session_manager_logging ? 1 : 0
+
+  name            = "SSM-SessionManagerRunShell"
+  document_type   = "Session"
+  document_format = "JSON"
+
+  content = jsonencode({
+    schemaVersion = "1.0"
+    description   = "Document to hold regional settings for Session Manager"
+    sessionType   = "Standard_Stream"
+
+    inputs = {
+      cloudWatchLogGroupName      = aws_cloudwatch_log_group.session_manager[0].name
+      cloudWatchEncryptionEnabled = false
+      cloudWatchStreamingEnabled  = true
+      s3BucketName                = ""
+      s3KeyPrefix                 = ""
+      s3EncryptionEnabled         = false
+      idleSessionTimeout          = tostring(var.session_manager_idle_timeout_minutes)
+      maxSessionDuration          = "720"
+      kmsKeyId                    = ""
+      runAsEnabled                = false
+      runAsDefaultUser            = ""
+
+      shellProfile = {
+        windows = ""
+        linux   = ""
+      }
+    }
+  })
+
+  tags = var.tags
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/modules/ssm/variables.tf
+++ b/modules/ssm/variables.tf
@@ -19,7 +19,12 @@ variable "session_manager_log_kms_key_id" {
 variable "session_manager_idle_timeout_minutes" {
   description = "Idle timeout in minutes for Session Manager shell sessions."
   type        = number
-  default     = 60
+  default     = 20
+
+  validation {
+    condition     = var.session_manager_idle_timeout_minutes >= 1 && var.session_manager_idle_timeout_minutes <= 60
+    error_message = "session_manager_idle_timeout_minutes must be between 1 and 60."
+  }
 }
 
 variable "tags" {

--- a/ssm.tf
+++ b/ssm.tf
@@ -4,7 +4,7 @@ module "ssm-baseline-eu-west-1" {
   providers = { aws = aws.eu-west-1 }
 
   enable_session_manager_logging        = local.enable_session_manager_logging && contains(var.session_manager_logging_regions, "eu-west-1")
-  session_manager_idle_timeout_minutes  = var.session_manager_idle_timeout_minutes
+  session_manager_idle_timeout_minutes  = local.session_manager_idle_timeout_minutes
   session_manager_log_kms_key_id        = var.session_manager_log_kms_key_id
   session_manager_log_retention_in_days = local.session_manager_log_retention_in_days
   tags                                  = var.tags
@@ -16,7 +16,7 @@ module "ssm-baseline-eu-west-2" {
   providers = { aws = aws.eu-west-2 }
 
   enable_session_manager_logging        = local.enable_session_manager_logging && contains(var.session_manager_logging_regions, "eu-west-2")
-  session_manager_idle_timeout_minutes  = var.session_manager_idle_timeout_minutes
+  session_manager_idle_timeout_minutes  = local.session_manager_idle_timeout_minutes
   session_manager_log_kms_key_id        = var.session_manager_log_kms_key_id
   session_manager_log_retention_in_days = local.session_manager_log_retention_in_days
   tags                                  = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -122,7 +122,6 @@ variable "session_manager_logging_excluded_applications" {
     "hmpps-domain-services",
     "planetfm",
     "prison-retail",
-    "moj-network-operations-centre",
   ]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -108,12 +108,6 @@ variable "session_manager_log_kms_key_id" {
   default     = null
 }
 
-variable "session_manager_idle_timeout_minutes" {
-  description = "Idle timeout in minutes for central Session Manager shell sessions."
-  type        = number
-  default     = 60
-}
-
 variable "session_manager_logging_excluded_applications" {
   description = "Applications excluded from central Session Manager transcript logging because they already manage it through the environments repo baseline preset."
   type        = set(string)
@@ -128,6 +122,7 @@ variable "session_manager_logging_excluded_applications" {
     "hmpps-domain-services",
     "planetfm",
     "prison-retail",
+    "moj-network-operations-centre",
   ]
 }
 


### PR DESCRIPTION
https://github.com/ministryofjustice/modernisation-platform-security/issues/114

This supports IP-58 by enabling consistent audit logging for SSM Session Manager sessions across instances.


This enables MP to centrally manage `SSM-SessionManagerRunShell` with:

- CloudWatch transcript logging to `session-manager-logs`
- CloudWatch streaming enabled
- 20 minute idle session timeout by default
- 60 minute idle timeout exceptions for agreed accounts
- 12 hour maximum session duration
- exclusions for applications already managing Session Manager logging elsewhere
